### PR TITLE
JAVA-6284 add server 9.0 test variant to evergreen

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -2520,7 +2520,7 @@ buildvariants:
   - matrix_name: "aws-auth-test"
     matrix_spec: { ssl: "nossl", jdk: [ "jdk8", "jdk17", "jdk21" ], version: [ "6.0", "7.0", "8.0", "9.0", "latest" ], os: "ubuntu2204",
                    aws-credential-provider: "*" }
-    display_name: "MONGODB-AWS Basic Auth test ${version} ${jdk} ${aws-credential-provider}"
+    display_name: "MONGODB-AWS Basic Auth test ${version} ${jdk} ${aws-credential-provider} ${os}"
     tasks:
       - name: "aws-auth-test-with-regular-aws-credentials-task"
 
@@ -2528,14 +2528,13 @@ buildvariants:
   - matrix_name: "aws-auth-test-ubuntu2004"
     matrix_spec: { ssl: "nossl", jdk: [ "jdk8", "jdk17", "jdk21" ], version: [ "4.4", "5.0" ], os: "ubuntu2004",
                    aws-credential-provider: "*" }
-    display_name: "MONGODB-AWS Basic Auth test ${version} ${jdk} ${aws-credential-provider}"
+    display_name: "MONGODB-AWS Basic Auth test ${version} ${jdk} ${aws-credential-provider} ${os}"
     tasks:
       - name: "aws-auth-test-with-regular-aws-credentials-task"
 
   - matrix_name: "aws-ec2-auth-test"
     matrix_spec: { ssl: "nossl", jdk: [ "jdk21" ], version: [ "7.0" ], os: "ubuntu2204", aws-credential-provider: "*" }
-    display_name: "MONGODB-AWS Advanced Auth test ${version} ${jdk} ${aws-credential-provider}"
-    run_on: "ubuntu2204-small"
+    display_name: "MONGODB-AWS Advanced Auth test ${version} ${jdk} ${aws-credential-provider} ${os}"
     tasks:
       - name: "aws-auth-test-with-aws-EC2-credentials-task"
       - name: "aws-auth-test-with-assume-role-credentials-task"

--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -1779,7 +1779,7 @@ axes:
         run_on: "rhel80-small"
       - id: "ubuntu"
         display_name: "Ubuntu"
-        run_on: "ubuntu2004-small"
+        run_on: "ubuntu2204-small"
       - id: "windows"
         display_name: "Windows"
         run_on: "windows-2022-latest-small"
@@ -2443,9 +2443,8 @@ buildvariants:
       - name: "test-core-task"
       - name: "test-legacy-task"
 
-  # TODO: 9.0 isn't published on ubuntu , but in RH
   - matrix_name: "tests-load-balancer-secure"
-    matrix_spec: { auth: "auth", ssl: "ssl", jdk: [ "jdk21" ], version: [ "5.0", "6.0", "7.0", "8.0", "latest" ], topology: "sharded-cluster",
+    matrix_spec: { auth: "auth", ssl: "ssl", jdk: [ "jdk21" ], version: [ "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], topology: "sharded-cluster",
                    os: "ubuntu" }
     display_name: "Load Balancer ${version} ${auth} ${ssl} ${jdk} ${os}"
     tasks:
@@ -2505,7 +2504,7 @@ buildvariants:
       - name: "gssapi-auth-test-task"
 
   - matrix_name: "aws-auth-test"
-    matrix_spec: { ssl: "nossl", jdk: [ "jdk8", "jdk17", "jdk21" ], version: [ "4.4", "5.0", "6.0", "7.0", "8.0", "latest" ], os: "ubuntu",
+    matrix_spec: { ssl: "nossl", jdk: [ "jdk8", "jdk17", "jdk21" ], version: [ "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], os: "ubuntu",
                    aws-credential-provider: "*" }
     display_name: "MONGODB-AWS Basic Auth test ${version} ${jdk} ${aws-credential-provider}"
     run_on: "ubuntu2204-small"
@@ -2532,7 +2531,7 @@ buildvariants:
       - name: "accept-api-version-2-test-task"
 
   - matrix_name: "ocsp-test"
-    matrix_spec: { auth: "noauth", ssl: "ssl", jdk: "jdk21", version: [ "4.4", "5.0", "6.0", "7.0", "8.0", "latest" ], os: "ubuntu" }
+    matrix_spec: { auth: "noauth", ssl: "ssl", jdk: "jdk21", version: [ "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], os: "ubuntu" }
     display_name: "OCSP test ${version} ${os}"
     tasks:
       - name: ".ocsp"

--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -1736,6 +1736,10 @@ axes:
         display_name: "latest"
         variables:
           VERSION: "latest"
+      - id: "9.0"
+        display_name: "9.0"
+        variables:
+          VERSION: "9.0"
       - id: "8.0"
         display_name: "8.0"
         variables:
@@ -2341,7 +2345,7 @@ buildvariants:
     #
 
   - matrix_name: "tests-zlib-compression"
-    matrix_spec: { compressor: "zlib", auth: "noauth", ssl: "nossl", jdk: "jdk8", version: [ "4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "latest" ], topology: "standalone", os: "linux" }
+    matrix_spec: { compressor: "zlib", auth: "noauth", ssl: "nossl", jdk: "jdk8", version: [ "4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], topology: "standalone", os: "linux" }
     display_name: "${version} ${compressor} ${topology} ${auth} ${ssl} ${jdk} ${os} "
     tags: [ "tests-variant" ]
     tasks:
@@ -2351,7 +2355,7 @@ buildvariants:
       - name: "test-legacy-task"
 
   - matrix_name: "tests-snappy-compression"
-    matrix_spec: { compressor: "snappy", auth: "noauth", ssl: "nossl", jdk: "jdk8", version: [ "4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "latest" ], topology: "standalone", os: "linux" }
+    matrix_spec: { compressor: "snappy", auth: "noauth", ssl: "nossl", jdk: "jdk8", version: [ "4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], topology: "standalone", os: "linux" }
     display_name: "${version} ${compressor} ${topology} ${auth} ${ssl} ${jdk} ${os} "
     tags: [ "tests-variant" ]
     tasks:
@@ -2362,7 +2366,7 @@ buildvariants:
 
   - matrix_name: "tests-zstd-compression"
     matrix_spec: { compressor: "zstd", auth: "noauth", ssl: "nossl", jdk: "jdk8",
-                   version: [ "4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "latest" ],
+                   version: [ "4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ],
                    topology: "standalone", os: "linux" }
     display_name: "${version} ${compressor} ${topology} ${auth} ${ssl} ${jdk} ${os} "
     tags: [ "tests-variant" ]
@@ -2380,7 +2384,7 @@ buildvariants:
       - name: "test-bson-and-crypt-task"
 
   - matrix_name: "tests-jdk8-unsecure"
-    matrix_spec: { auth: "noauth", ssl: "nossl", jdk: "jdk8", version: [ "4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "latest" ],
+    matrix_spec: { auth: "noauth", ssl: "nossl", jdk: "jdk8", version: [ "4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ],
                    topology: "*", os: "linux" }
     display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
     tags: [ "tests-variant" ]
@@ -2392,7 +2396,7 @@ buildvariants:
 
   - matrix_name: "tests-jdk-secure"
     matrix_spec: { auth: "auth", ssl: "ssl", jdk: [ "jdk8", "jdk17", "jdk21" ],
-                   version: [ "4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "latest" ],
+                   version: [ "4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ],
                    topology: "*", os: "linux" }
     display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
     tags: [ "tests-variant" ]
@@ -2429,7 +2433,7 @@ buildvariants:
         exec_timeout_secs: 7200
 
   - matrix_name: "tests-require-api-version"
-    matrix_spec: { api-version: "required", auth: "auth", ssl: "nossl", jdk: [ "jdk21" ], version: [ "5.0", "6.0", "7.0", "8.0", "latest" ],
+    matrix_spec: { api-version: "required", auth: "auth", ssl: "nossl", jdk: [ "jdk21" ], version: [ "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ],
                    topology: "standalone", os: "linux" }
     display_name: "${version} ${topology} ${api-version} "
     tags: [ "tests-variant" ]
@@ -2440,7 +2444,7 @@ buildvariants:
       - name: "test-legacy-task"
 
   - matrix_name: "tests-load-balancer-secure"
-    matrix_spec: { auth: "auth", ssl: "ssl", jdk: [ "jdk21" ], version: [ "5.0", "6.0", "7.0", "8.0", "latest" ], topology: "sharded-cluster",
+    matrix_spec: { auth: "auth", ssl: "ssl", jdk: [ "jdk21" ], version: [ "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], topology: "sharded-cluster",
                    os: "ubuntu" }
     display_name: "Load Balancer ${version} ${auth} ${ssl} ${jdk} ${os}"
     tasks:
@@ -2500,7 +2504,7 @@ buildvariants:
       - name: "gssapi-auth-test-task"
 
   - matrix_name: "aws-auth-test"
-    matrix_spec: { ssl: "nossl", jdk: [ "jdk8", "jdk17", "jdk21" ], version: [ "4.4", "5.0", "6.0", "7.0", "8.0", "latest" ], os: "ubuntu",
+    matrix_spec: { ssl: "nossl", jdk: [ "jdk8", "jdk17", "jdk21" ], version: [ "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], os: "ubuntu",
                    aws-credential-provider: "*" }
     display_name: "MONGODB-AWS Basic Auth test ${version} ${jdk} ${aws-credential-provider}"
     run_on: "ubuntu2204-small"
@@ -2519,7 +2523,7 @@ buildvariants:
       - name: "aws-auth-test-with-web-identity-credentials-task"
 
   - matrix_name: "accept-api-version-2-test"
-    matrix_spec: { ssl: "nossl", auth: "noauth", jdk: "jdk21", version: [ "5.0", "6.0", "7.0", "8.0", "latest" ], topology: "standalone",
+    matrix_spec: { ssl: "nossl", auth: "noauth", jdk: "jdk21", version: [ "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], topology: "standalone",
                    os: "linux" }
     display_name: "Accept API Version 2 ${version}"
     run_on: "ubuntu2204-small"
@@ -2527,7 +2531,7 @@ buildvariants:
       - name: "accept-api-version-2-test-task"
 
   - matrix_name: "ocsp-test"
-    matrix_spec: { auth: "noauth", ssl: "ssl", jdk: "jdk21", version: [ "4.4", "5.0", "6.0", "7.0", "8.0", "latest" ], os: "ubuntu" }
+    matrix_spec: { auth: "noauth", ssl: "ssl", jdk: "jdk21", version: [ "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], os: "ubuntu" }
     display_name: "OCSP test ${version} ${os}"
     tasks:
       - name: ".ocsp"
@@ -2560,14 +2564,14 @@ buildvariants:
       - name: ".csfle-aws-from-environment"
 
   - matrix_name: "csfle-tests-with-mongocryptd"
-    matrix_spec: { os: "linux", version: [ "4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "latest" ], topology: [ "replicaset" ] }
+    matrix_spec: { os: "linux", version: [ "4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], topology: [ "replicaset" ] }
     display_name: "CSFLE with mongocryptd: ${version}"
     tasks:
       - name: "csfle-tests-with-mongocryptd-task"
 
   - matrix_name: "csfle-tests-with-mongocryptd-windows"
     matrix_spec: { os: "windows",
-                   version: [ "8.0", "latest" ],
+                   version: [ "8.0", "9.0", "latest" ],
                    topology: [ "replicaset" ] }
     display_name: "${os} CSFLE with mongocryptd: ${version}"
     tasks:

--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -1777,8 +1777,14 @@ axes:
       - id: "linux"
         display_name: "Linux"
         run_on: "rhel80-small"
-      - id: "ubuntu"
-        display_name: "Ubuntu"
+      # No single Ubuntu release has server builds for every version we test: 4.4 and 5.0 stop at
+      # ubuntu2004, while 9.0 starts at ubuntu2204. mongodl infers the download target from the host
+      # distro and does not fall back to an older target, so the host must match the server release.
+      - id: "ubuntu2004"
+        display_name: "Ubuntu 20.04"
+        run_on: "ubuntu2004-small"
+      - id: "ubuntu2204"
+        display_name: "Ubuntu 22.04"
         run_on: "ubuntu2204-small"
       - id: "windows"
         display_name: "Windows"
@@ -2444,8 +2450,16 @@ buildvariants:
       - name: "test-legacy-task"
 
   - matrix_name: "tests-load-balancer-secure"
-    matrix_spec: { auth: "auth", ssl: "ssl", jdk: [ "jdk21" ], version: [ "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], topology: "sharded-cluster",
-                   os: "ubuntu" }
+    matrix_spec: { auth: "auth", ssl: "ssl", jdk: [ "jdk21" ], version: [ "6.0", "7.0", "8.0", "9.0", "latest" ], topology: "sharded-cluster",
+                   os: "ubuntu2204" }
+    display_name: "Load Balancer ${version} ${auth} ${ssl} ${jdk} ${os}"
+    tasks:
+      - name: "load-balancer-test-task"
+
+  # 5.0 has no ubuntu2204 server build, so it stays on ubuntu2004.
+  - matrix_name: "tests-load-balancer-secure-ubuntu2004"
+    matrix_spec: { auth: "auth", ssl: "ssl", jdk: [ "jdk21" ], version: [ "5.0" ], topology: "sharded-cluster",
+                   os: "ubuntu2004" }
     display_name: "Load Balancer ${version} ${auth} ${ssl} ${jdk} ${os}"
     tasks:
       - name: "load-balancer-test-task"
@@ -2504,15 +2518,22 @@ buildvariants:
       - name: "gssapi-auth-test-task"
 
   - matrix_name: "aws-auth-test"
-    matrix_spec: { ssl: "nossl", jdk: [ "jdk8", "jdk17", "jdk21" ], version: [ "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], os: "ubuntu",
+    matrix_spec: { ssl: "nossl", jdk: [ "jdk8", "jdk17", "jdk21" ], version: [ "6.0", "7.0", "8.0", "9.0", "latest" ], os: "ubuntu2204",
                    aws-credential-provider: "*" }
     display_name: "MONGODB-AWS Basic Auth test ${version} ${jdk} ${aws-credential-provider}"
-    run_on: "ubuntu2204-small"
+    tasks:
+      - name: "aws-auth-test-with-regular-aws-credentials-task"
+
+  # 4.4 and 5.0 have no ubuntu2204 server build, so they stay on ubuntu2004.
+  - matrix_name: "aws-auth-test-ubuntu2004"
+    matrix_spec: { ssl: "nossl", jdk: [ "jdk8", "jdk17", "jdk21" ], version: [ "4.4", "5.0" ], os: "ubuntu2004",
+                   aws-credential-provider: "*" }
+    display_name: "MONGODB-AWS Basic Auth test ${version} ${jdk} ${aws-credential-provider}"
     tasks:
       - name: "aws-auth-test-with-regular-aws-credentials-task"
 
   - matrix_name: "aws-ec2-auth-test"
-    matrix_spec: { ssl: "nossl", jdk: [ "jdk21" ], version: [ "7.0" ], os: "ubuntu", aws-credential-provider: "*" }
+    matrix_spec: { ssl: "nossl", jdk: [ "jdk21" ], version: [ "7.0" ], os: "ubuntu2204", aws-credential-provider: "*" }
     display_name: "MONGODB-AWS Advanced Auth test ${version} ${jdk} ${aws-credential-provider}"
     run_on: "ubuntu2204-small"
     tasks:
@@ -2531,21 +2552,28 @@ buildvariants:
       - name: "accept-api-version-2-test-task"
 
   - matrix_name: "ocsp-test"
-    matrix_spec: { auth: "noauth", ssl: "ssl", jdk: "jdk21", version: [ "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], os: "ubuntu" }
+    matrix_spec: { auth: "noauth", ssl: "ssl", jdk: "jdk21", version: [ "6.0", "7.0", "8.0", "9.0", "latest" ], os: "ubuntu2204" }
+    display_name: "OCSP test ${version} ${os}"
+    tasks:
+      - name: ".ocsp"
+
+  # 4.4 and 5.0 have no ubuntu2204 server build, so they stay on ubuntu2004.
+  - matrix_name: "ocsp-test-ubuntu2004"
+    matrix_spec: { auth: "noauth", ssl: "ssl", jdk: "jdk21", version: [ "4.4", "5.0" ], os: "ubuntu2004" }
     display_name: "OCSP test ${version} ${os}"
     tasks:
       - name: ".ocsp"
 
   - matrix_name: "scala-tests"
     matrix_spec: { auth: "noauth", ssl: "nossl", jdk: [ "jdk8", "jdk17", "jdk21" ], version: [ "7.0" ], topology: "replicaset",
-                   scala: "*" , os: "ubuntu" }
+                   scala: "*" , os: "ubuntu2204" }
     display_name: "${scala} ${jdk} ${version} ${topology} ${os}"
     tags: [ "test-scala-variant" ]
     tasks:
       - name: "scala-test-task"
 
   - matrix_name: "kotlin-tests"
-    matrix_spec: { auth: "noauth", ssl: "nossl", jdk: [ "jdk8", "jdk17", "jdk21" ], version: [ "7.0" ], topology: "replicaset", os: "ubuntu" }
+    matrix_spec: { auth: "noauth", ssl: "nossl", jdk: [ "jdk8", "jdk17", "jdk21" ], version: [ "7.0" ], topology: "replicaset", os: "ubuntu2204" }
     display_name: "Kotlin: ${jdk} ${version} ${topology} ${os}"
     tags: [ "test-kotlin-variant" ]
     tasks:

--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -2443,8 +2443,9 @@ buildvariants:
       - name: "test-core-task"
       - name: "test-legacy-task"
 
+  # TODO: 9.0 isn't published on ubuntu , but in RH
   - matrix_name: "tests-load-balancer-secure"
-    matrix_spec: { auth: "auth", ssl: "ssl", jdk: [ "jdk21" ], version: [ "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], topology: "sharded-cluster",
+    matrix_spec: { auth: "auth", ssl: "ssl", jdk: [ "jdk21" ], version: [ "5.0", "6.0", "7.0", "8.0", "latest" ], topology: "sharded-cluster",
                    os: "ubuntu" }
     display_name: "Load Balancer ${version} ${auth} ${ssl} ${jdk} ${os}"
     tasks:
@@ -2504,7 +2505,7 @@ buildvariants:
       - name: "gssapi-auth-test-task"
 
   - matrix_name: "aws-auth-test"
-    matrix_spec: { ssl: "nossl", jdk: [ "jdk8", "jdk17", "jdk21" ], version: [ "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], os: "ubuntu",
+    matrix_spec: { ssl: "nossl", jdk: [ "jdk8", "jdk17", "jdk21" ], version: [ "4.4", "5.0", "6.0", "7.0", "8.0", "latest" ], os: "ubuntu",
                    aws-credential-provider: "*" }
     display_name: "MONGODB-AWS Basic Auth test ${version} ${jdk} ${aws-credential-provider}"
     run_on: "ubuntu2204-small"
@@ -2531,7 +2532,7 @@ buildvariants:
       - name: "accept-api-version-2-test-task"
 
   - matrix_name: "ocsp-test"
-    matrix_spec: { auth: "noauth", ssl: "ssl", jdk: "jdk21", version: [ "4.4", "5.0", "6.0", "7.0", "8.0", "9.0", "latest" ], os: "ubuntu" }
+    matrix_spec: { auth: "noauth", ssl: "ssl", jdk: "jdk21", version: [ "4.4", "5.0", "6.0", "7.0", "8.0", "latest" ], os: "ubuntu" }
     display_name: "OCSP test ${version} ${os}"
     tasks:
       - name: ".ocsp"

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version=5.11.0-SNAPSHOT
+version=5.12.0-SNAPSHOT
 
 org.gradle.daemon=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version=5.10.0-SNAPSHOT
+version=5.11.0-SNAPSHOT
 
 org.gradle.daemon=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en


### PR DESCRIPTION
[JAVA-6284 ](https://jira.mongodb.org/browse/JAVA-6284) add server 9.0 test variant to evergreen 
Also because 9.0 is not publishing ubuntu2004 version the ubuntu matrix was split into two 
1. 20.04
2. 22.04

The server versions 4.4 and 5.0 work with 20.04
