### PR TITLE
Java 6173 CSFLE/QE Support for HTTP Proxies

### DIFF
--- a/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
+++ b/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
@@ -69,6 +69,8 @@ public final class AutoEncryptionSettings {
     private final String keyVaultNamespace;
     private final Map<String, Map<String, Object>> kmsProviders;
     private final Map<String, SSLContext> kmsProviderSslContextMap;
+    @Nullable
+    private final KmsConnectCallback kmsConnectCallback;
     private final Map<String, Supplier<Map<String, Object>>> kmsProviderPropertySuppliers;
     private final Map<String, BsonDocument> schemaMap;
     private final Map<String, Object> extraOptions;
@@ -88,6 +90,8 @@ public final class AutoEncryptionSettings {
         private String keyVaultNamespace;
         private Map<String, Map<String, Object>> kmsProviders;
         private Map<String, SSLContext> kmsProviderSslContextMap = new HashMap<>();
+        @Nullable
+        private KmsConnectCallback kmsConnectCallback;
         private Map<String, Supplier<Map<String, Object>>> kmsProviderPropertySuppliers = new HashMap<>();
         private Map<String, BsonDocument> schemaMap = Collections.emptyMap();
         private Map<String, Object> extraOptions = Collections.emptyMap();
@@ -159,6 +163,22 @@ public final class AutoEncryptionSettings {
          */
         public Builder kmsProviderSslContextMap(final Map<String, SSLContext> kmsProviderSslContextMap) {
             this.kmsProviderSslContextMap = notNull("kmsProviderSslContextMap", kmsProviderSslContextMap);
+            return this;
+        }
+
+        /**
+         * Sets the callback that establishes connections to Key Management Service (KMS) hosts, enabling KMS requests
+         * to be routed through an intermediary such as an HTTP proxy.
+         *
+         * <p>Defaults to {@code null}, in which case the driver connects to KMS hosts directly.</p>
+         *
+         * @param kmsConnectCallback the KMS connect callback, or null to connect to KMS hosts directly
+         * @return this
+         * @see #getKmsConnectCallback()
+         * @since 5.11
+         */
+        public Builder kmsConnectCallback(@Nullable final KmsConnectCallback kmsConnectCallback) {
+            this.kmsConnectCallback = kmsConnectCallback;
             return this;
         }
 
@@ -407,6 +427,17 @@ public final class AutoEncryptionSettings {
     }
 
     /**
+     * Gets the callback that establishes connections to Key Management Service (KMS) hosts.
+     *
+     * @return the KMS connect callback, or null if the driver connects to KMS hosts directly
+     * @since 5.11
+     */
+    @Nullable
+    public KmsConnectCallback getKmsConnectCallback() {
+        return kmsConnectCallback;
+    }
+
+    /**
      * Gets the map of namespace to local JSON schema.
      * <p>
      * Automatic encryption is configured with an "encrypt" field in a collection's JSONSchema. By default, a collection's JSONSchema is
@@ -529,6 +560,7 @@ public final class AutoEncryptionSettings {
         this.keyVaultNamespace = notNull("keyVaultNamespace", builder.keyVaultNamespace);
         this.kmsProviders = notNull("kmsProviders", builder.kmsProviders);
         this.kmsProviderSslContextMap = notNull("kmsProviderSslContextMap", builder.kmsProviderSslContextMap);
+        this.kmsConnectCallback = builder.kmsConnectCallback;
         this.kmsProviderPropertySuppliers = notNull("kmsProviderPropertySuppliers", builder.kmsProviderPropertySuppliers);
         this.schemaMap = notNull("schemaMap", builder.schemaMap);
         this.extraOptions = notNull("extraOptions", builder.extraOptions);

--- a/driver-core/src/main/com/mongodb/ClientEncryptionSettings.java
+++ b/driver-core/src/main/com/mongodb/ClientEncryptionSettings.java
@@ -50,6 +50,8 @@ public final class ClientEncryptionSettings {
     private final Map<String, Supplier<Map<String, Object>>> kmsProviderPropertySuppliers;
     private final Map<String, SSLContext> kmsProviderSslContextMap;
     @Nullable
+    private final KmsConnectCallback kmsConnectCallback;
+    @Nullable
     private final Long timeoutMS;
     @Nullable
     private final Long keyExpirationMS;
@@ -65,6 +67,8 @@ public final class ClientEncryptionSettings {
         private Map<String, Map<String, Object>> kmsProviders;
         private Map<String, Supplier<Map<String, Object>>> kmsProviderPropertySuppliers = new HashMap<>();
         private Map<String, SSLContext> kmsProviderSslContextMap = new HashMap<>();
+        @Nullable
+        private KmsConnectCallback kmsConnectCallback;
         @Nullable
         private Long timeoutMS;
         @Nullable
@@ -133,6 +137,22 @@ public final class ClientEncryptionSettings {
          */
         public Builder kmsProviderSslContextMap(final Map<String, SSLContext> kmsProviderSslContextMap) {
             this.kmsProviderSslContextMap = notNull("kmsProviderSslContextMap", kmsProviderSslContextMap);
+            return this;
+        }
+
+        /**
+         * Sets the callback that establishes connections to Key Management Service (KMS) hosts, enabling KMS requests
+         * to be routed through an intermediary such as an HTTP proxy.
+         *
+         * <p>Defaults to {@code null}, in which case the driver connects to KMS hosts directly.</p>
+         *
+         * @param kmsConnectCallback the KMS connect callback, or null to connect to KMS hosts directly
+         * @return this
+         * @see #getKmsConnectCallback()
+         * @since 5.11
+         */
+        public Builder kmsConnectCallback(@Nullable final KmsConnectCallback kmsConnectCallback) {
+            this.kmsConnectCallback = kmsConnectCallback;
             return this;
         }
 
@@ -336,6 +356,17 @@ public final class ClientEncryptionSettings {
     }
 
     /**
+     * Gets the callback that establishes connections to Key Management Service (KMS) hosts.
+     *
+     * @return the KMS connect callback, or null if the driver connects to KMS hosts directly
+     * @since 5.11
+     */
+    @Nullable
+    public KmsConnectCallback getKmsConnectCallback() {
+        return kmsConnectCallback;
+    }
+
+    /**
      * Returns the cache expiration time for data encryption keys.
      *
      * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently {@code 60000 ms}.
@@ -399,6 +430,7 @@ public final class ClientEncryptionSettings {
         this.kmsProviders = notNull("kmsProviders", builder.kmsProviders);
         this.kmsProviderPropertySuppliers = notNull("kmsProviderPropertySuppliers", builder.kmsProviderPropertySuppliers);
         this.kmsProviderSslContextMap = notNull("kmsProviderSslContextMap", builder.kmsProviderSslContextMap);
+        this.kmsConnectCallback = builder.kmsConnectCallback;
         this.timeoutMS = builder.timeoutMS;
         this.keyExpirationMS = builder.keyExpirationMS;
     }

--- a/driver-core/src/main/com/mongodb/KmsConnectCallback.java
+++ b/driver-core/src/main/com/mongodb/KmsConnectCallback.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+import com.mongodb.annotations.ThreadSafe;
+
+import java.io.IOException;
+import java.net.Socket;
+
+/**
+ * A callback that establishes the connection used for a Key Management Service (KMS) request made by in-use encryption
+ * (client-side field level encryption or queryable encryption).
+ *
+ * <p>When a callback is configured, the driver invokes it instead of connecting to the KMS host itself, and uses the
+ * socket it returns for the KMS request. This enables routing KMS requests through an intermediary, most commonly an
+ * HTTP proxy via the {@code HTTP CONNECT} method.</p>
+ *
+ * <p>The driver always negotiates TLS with the KMS host itself over the returned socket, using the
+ * {@link javax.net.ssl.SSLContext} configured for the KMS provider. Server Name Indication and certificate hostname
+ * verification target {@link KmsConnectContext#getServerAddress()}, not the address the callback actually connected to.
+ * Implementations therefore MUST NOT negotiate TLS with the KMS host themselves; they must return a socket over which
+ * a TLS handshake with the KMS host can be performed. An implementation may use TLS for its own connection to an
+ * intermediary, in which case it returns an {@link javax.net.ssl.SSLSocket} and the driver layers the KMS host's TLS
+ * session on top of it.</p>
+ *
+ * <p>An {@link IOException} thrown by an implementation is treated as a transient network error.</p>
+ *
+ * <p>Authenticating to an intermediary is the responsibility of the implementation. For a proxy requiring HTTP Basic
+ * authentication, for example, the implementation adds a {@code Proxy-Authorization} header to the {@code CONNECT}
+ * request.</p>
+ *
+ * <p>Example of an implementation that tunnels through an HTTP proxy:</p>
+ * <pre>{@code
+ * KmsConnectCallback callback = context -> {
+ *     Socket socket = new Socket();
+ *     int timeout = (int) context.getTimeoutMillis();
+ *     socket.connect(new InetSocketAddress("proxy.example.com", 8080), timeout);
+ *     socket.setSoTimeout(timeout);
+ *
+ *     String target = context.getServerAddress().getHost() + ":" + context.getServerAddress().getPort();
+ *     socket.getOutputStream().write(
+ *             ("CONNECT " + target + " HTTP/1.1\r\nHost: " + target + "\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
+ *
+ *     // Read the status line and confirm a 2xx status, throwing an IOException otherwise. Match the status code
+ *     // rather than the whole status line, as proxies differ in the HTTP version they reply with. Read the response
+ *     // one byte at a time, up to the end of the header block, so that no byte of the TLS handshake that the driver
+ *     // performs over this socket is consumed.
+ *     readAndCheckProxyResponse(socket.getInputStream());
+ *
+ *     return socket;
+ * };
+ * }</pre>
+ *
+ * @see ClientEncryptionSettings.Builder#kmsConnectCallback(KmsConnectCallback)
+ * @see AutoEncryptionSettings.Builder#kmsConnectCallback(KmsConnectCallback)
+ * @since 5.11
+ */
+@ThreadSafe
+@FunctionalInterface
+public interface KmsConnectCallback {
+    /**
+     * Returns a socket connected such that a TLS handshake with the KMS host can be performed over it.
+     *
+     * <p>Ownership of the returned socket passes to the driver, which closes it once the KMS request completes.</p>
+     *
+     * @param context the details of the connection to establish, which may gain further properties in future releases
+     * @return a connected socket, which must not have an established TLS session with the KMS host
+     * @throws IOException if the connection cannot be established. This is treated as a transient network error.
+     */
+    Socket connect(KmsConnectContext context) throws IOException;
+}

--- a/driver-core/src/main/com/mongodb/KmsConnectContext.java
+++ b/driver-core/src/main/com/mongodb/KmsConnectContext.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+import com.mongodb.annotations.Immutable;
+
+import static com.mongodb.assertions.Assertions.isTrueArgument;
+import static com.mongodb.assertions.Assertions.notNull;
+
+/**
+ * The details of a Key Management Service (KMS) connection that a {@link KmsConnectCallback} is asked to establish.
+ *
+ * <p>Instances are created by the driver. Further properties may be added in future releases, so implementations of
+ * {@link KmsConnectCallback} must not assume that this type is complete.</p>
+ *
+ * @see KmsConnectCallback
+ * @since 5.11
+ */
+@Immutable
+public final class KmsConnectContext {
+    private final String kmsProvider;
+    private final ServerAddress serverAddress;
+    private final long timeoutMillis;
+
+    /**
+     * This constructor is not part of the public API and may be removed or changed at any time.
+     *
+     * @param kmsProvider the KMS provider
+     * @param serverAddress the address of the KMS host
+     * @param timeoutMillis the remaining time available, or 0 if no time limit applies
+     */
+    public KmsConnectContext(final String kmsProvider, final ServerAddress serverAddress, final long timeoutMillis) {
+        this.kmsProvider = notNull("kmsProvider", kmsProvider);
+        this.serverAddress = notNull("serverAddress", serverAddress);
+        isTrueArgument("timeoutMillis >= 0", timeoutMillis >= 0);
+        this.timeoutMillis = timeoutMillis;
+    }
+
+    /**
+     * Gets the KMS provider that this connection is being established for.
+     *
+     * <p>This is one of the keys of the configured {@code kmsProviders} map, so either a provider name such as
+     * {@code "aws"} or a named provider such as {@code "aws:myname"}. Implementations must accept arbitrary values for
+     * forward compatibility: rather than rejecting an unrecognized provider, connect using a default route.</p>
+     *
+     * @return the KMS provider, never null
+     */
+    public String getKmsProvider() {
+        return kmsProvider;
+    }
+
+    /**
+     * Gets the address of the KMS host that the connection must ultimately reach.
+     *
+     * <p>This is not the address of any intermediary such as a proxy. It is the address that the driver negotiates TLS
+     * with once the callback returns.</p>
+     *
+     * @return the address of the KMS host, never null
+     */
+    public ServerAddress getServerAddress() {
+        return serverAddress;
+    }
+
+    /**
+     * Gets the time available to establish the connection, in milliseconds.
+     *
+     * <p>When a timeout is configured this is the time remaining in the operation, so it shrinks as the operation
+     * progresses. It is {@code 0} when no time limit applies.</p>
+     *
+     * @return the time available in milliseconds, or 0 if no time limit applies
+     */
+    public long getTimeoutMillis() {
+        return timeoutMillis;
+    }
+
+    @Override
+    public String toString() {
+        return "KmsConnectContext{"
+                + "kmsProvider='" + kmsProvider + '\''
+                + ", serverAddress=" + serverAddress
+                + ", timeoutMillis=" + timeoutMillis
+                + '}';
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/capi/KmsSocketConnector.java
+++ b/driver-core/src/main/com/mongodb/internal/capi/KmsSocketConnector.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.capi;
+
+import com.mongodb.KmsConnectCallback;
+import com.mongodb.KmsConnectContext;
+import com.mongodb.ServerAddress;
+import com.mongodb.internal.connection.SslHelper;
+import com.mongodb.lang.Nullable;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+/**
+ * Establishes the TLS connection used for a Key Management Service (KMS) request.
+ *
+ * <p>When a {@link KmsConnectCallback} is configured, the callback establishes the underlying connection, which may be
+ * to an intermediary such as an HTTP proxy, and TLS for the KMS host is layered on top of the socket it returns. TLS is
+ * always negotiated end-to-end with the KMS host: Server Name Indication and certificate hostname verification are
+ * configured from the KMS address rather than from wherever the socket is actually connected, so an intermediary
+ * relays the session without being able to read it.</p>
+ *
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+public final class KmsSocketConnector {
+
+    /**
+     * Connects to the KMS host and returns a socket with an established TLS session.
+     *
+     * @param sslContext the SSL context configured for the KMS provider, or null to use the default
+     * @param kmsConnectCallback the callback that establishes the connection, or null to connect directly
+     * @param kmsProvider the KMS provider that the request belongs to, passed on to {@code kmsConnectCallback}
+     * @param kmsAddress the address of the KMS host
+     * @param soTimeoutMillis the socket read timeout to apply
+     * @param connectTimeoutMillis the time available to establish the connection, or 0 if no limit applies
+     * @return a connected socket with an established TLS session with the KMS host
+     * @throws IOException if the connection or the TLS handshake fails
+     */
+    public static SSLSocket connect(@Nullable final SSLContext sslContext,
+            @Nullable final KmsConnectCallback kmsConnectCallback, final String kmsProvider,
+            final ServerAddress kmsAddress, final int soTimeoutMillis, final long connectTimeoutMillis)
+            throws IOException {
+        SSLSocketFactory sslSocketFactory = sslContext == null
+                ? (SSLSocketFactory) SSLSocketFactory.getDefault() : sslContext.getSocketFactory();
+
+        if (kmsConnectCallback == null) {
+            return connectDirectly(sslSocketFactory, kmsAddress, soTimeoutMillis, connectTimeoutMillis);
+        }
+        return connectViaCallback(sslSocketFactory, kmsConnectCallback, kmsProvider, kmsAddress, soTimeoutMillis,
+                connectTimeoutMillis);
+    }
+
+    private static SSLSocket connectDirectly(final SSLSocketFactory sslSocketFactory, final ServerAddress kmsAddress,
+            final int soTimeoutMillis, final long connectTimeoutMillis) throws IOException {
+        SSLSocket socket = (SSLSocket) sslSocketFactory.createSocket();
+        SSLParameters sslParameters = socket.getSSLParameters();
+        SslHelper.enableHostNameVerification(sslParameters);
+        socket.setSSLParameters(sslParameters);
+        try {
+            socket.setSoTimeout(soTimeoutMillis);
+            socket.connect(new InetSocketAddress(InetAddress.getByName(kmsAddress.getHost()), kmsAddress.getPort()),
+                    Math.toIntExact(connectTimeoutMillis));
+        } catch (IOException | RuntimeException e) {
+            closeSocket(socket);
+            throw e;
+        }
+        return socket;
+    }
+
+    /**
+     * Obtains a socket from the callback, then layers TLS for the KMS host on top of it. The callback may have
+     * connected to an intermediary, so Server Name Indication and hostname verification are configured from
+     * {@code kmsAddress} rather than from the address the socket is actually connected to.
+     */
+    private static SSLSocket connectViaCallback(final SSLSocketFactory sslSocketFactory,
+            final KmsConnectCallback kmsConnectCallback, final String kmsProvider, final ServerAddress kmsAddress,
+            final int soTimeoutMillis, final long connectTimeoutMillis) throws IOException {
+        Socket connectedSocket = notNull("socket returned by KmsConnectCallback",
+                kmsConnectCallback.connect(new KmsConnectContext(kmsProvider, kmsAddress, connectTimeoutMillis)));
+
+        SSLSocket socket;
+        try {
+            // Layers TLS over the already-connected socket. autoClose ensures that closing the returned socket also
+            // closes the socket the callback established.
+            socket = (SSLSocket) sslSocketFactory.createSocket(connectedSocket, kmsAddress.getHost(), kmsAddress.getPort(), true);
+        } catch (IOException | RuntimeException e) {
+            closeSocket(connectedSocket);
+            throw e;
+        }
+
+        try {
+            // Even though the callback's connection is already established, the TLS handshake has not been performed
+            // yet, so SSL parameters can still be set. They target the KMS host, not any intermediary.
+            SSLParameters sslParameters = socket.getSSLParameters();
+            SslHelper.enableSni(kmsAddress.getHost(), sslParameters);
+            SslHelper.enableHostNameVerification(sslParameters);
+            socket.setSSLParameters(sslParameters);
+            socket.setSoTimeout(soTimeoutMillis);
+            // Handshake explicitly so that a TLS failure is reported here rather than on the first write.
+            socket.startHandshake();
+        } catch (IOException | RuntimeException e) {
+            closeSocket(socket);
+            throw e;
+        }
+        return socket;
+    }
+
+    private static void closeSocket(final Socket socket) {
+        try {
+            socket.close();
+        } catch (IOException | RuntimeException e) {
+            // ignore
+        }
+    }
+
+    private KmsSocketConnector() {
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/KmsConnectCallbackSettingsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/KmsConnectCallbackSettingsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.Socket;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+final class KmsConnectCallbackSettingsTest {
+
+    private static final KmsConnectCallback CALLBACK = context -> new Socket();
+
+    @Test
+    void autoEncryptionSettingsShouldDefaultToNoCallback() {
+        AutoEncryptionSettings settings = AutoEncryptionSettings.builder()
+                .keyVaultNamespace("keyvault.datakeys")
+                .kmsProviders(new HashMap<>())
+                .build();
+
+        assertNull(settings.getKmsConnectCallback());
+    }
+
+    @Test
+    void autoEncryptionSettingsShouldRoundTripCallback() {
+        AutoEncryptionSettings settings = AutoEncryptionSettings.builder()
+                .keyVaultNamespace("keyvault.datakeys")
+                .kmsProviders(new HashMap<>())
+                .kmsConnectCallback(CALLBACK)
+                .build();
+
+        assertSame(CALLBACK, settings.getKmsConnectCallback());
+    }
+
+    @Test
+    void clientEncryptionSettingsShouldDefaultToNoCallback() {
+        ClientEncryptionSettings settings = clientEncryptionSettingsBuilder().build();
+
+        assertNull(settings.getKmsConnectCallback());
+    }
+
+    @Test
+    void clientEncryptionSettingsShouldRoundTripCallback() {
+        ClientEncryptionSettings settings = clientEncryptionSettingsBuilder()
+                .kmsConnectCallback(CALLBACK)
+                .build();
+
+        assertSame(CALLBACK, settings.getKmsConnectCallback());
+    }
+
+    private static ClientEncryptionSettings.Builder clientEncryptionSettingsBuilder() {
+        return ClientEncryptionSettings.builder()
+                .keyVaultMongoClientSettings(MongoClientSettings.builder().build())
+                .keyVaultNamespace("keyvault.datakeys")
+                .kmsProviders(new HashMap<>());
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/capi/KmsSocketConnectorTunnelTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/capi/KmsSocketConnectorTunnelTest.java
@@ -1,0 +1,476 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.capi;
+
+import com.mongodb.KmsConnectCallback;
+import com.mongodb.KmsConnectContext;
+import com.mongodb.ServerAddress;
+import com.mongodb.lang.Nullable;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the driver layers TLS for the KMS host on the socket a {@link KmsConnectCallback} returns, including
+ * when that socket is tunneled to an intermediary.
+ *
+ * <p>The callback here performs the {@code HTTP CONNECT} exchange, which is what a user of the API is expected to
+ * implement; the driver contributes only the TLS half.</p>
+ *
+ * <p>Everything this test needs runs in-process: a minimal {@code HTTP CONNECT} proxy, a TLS server standing in for the
+ * KMS host, and a keystore loaded from test resources. There is no dependency on a network, on credentials, or on any
+ * external process, so it covers the tunneling behaviour that
+ * {@code AbstractClientSideEncryptionKmsConnectCallbackProseTest} can only cover where real AWS credentials are available.</p>
+ */
+final class KmsSocketConnectorTunnelTest {
+
+    private static final char[] KEYSTORE_PASSWORD = "changeit".toCharArray();
+
+    /**
+     * Generated once per run rather than committed, so that no private key lives in the repository and nothing can
+     * expire. The certificate is issued for the IP address 127.0.0.1 and for no other name, which
+     * {@link #shouldVerifyCertificateAgainstKmsHostRatherThanProxy()} relies on.
+     */
+    private static Path keyStoreDir;
+    private static Path keyStorePath;
+
+    /** The certificate in the keystore is issued for the IP address 127.0.0.1 and for no other name. */
+    private static final String CERTIFIED_HOST = "127.0.0.1";
+
+    private static final int TIMEOUT_MILLIS = 10_000;
+
+    private final List<Closeable> toClose = new ArrayList<>();
+    private final List<Thread> threads = new ArrayList<>();
+
+    private FakeKmsServer kmsServer;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        kmsServer = new FakeKmsServer();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        for (Closeable closeable : toClose) {
+            try {
+                closeable.close();
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+        for (Thread thread : threads) {
+            thread.join(5_000);
+        }
+    }
+
+    @Test
+    void shouldConnectDirectlyWhenNoCallbackIsConfigured() throws Exception {
+        SSLSocket socket = connect(null);
+
+        assertEquals("PONG", exchange(socket, "PING"));
+        assertEquals("PING", kmsServer.received());
+    }
+
+    @Test
+    void shouldLayerTlsOnASocketFromTheCallback() throws Exception {
+        ConnectProxy proxy = new ConnectProxy(false);
+
+        SSLSocket socket = connect(proxy.callback(false));
+
+        assertEquals("PONG", exchange(socket, "PING"));
+        assertEquals("PING", kmsServer.received(), "the KMS host must receive what was written to the tunneled socket");
+        assertEquals(1, proxy.connectCount(), "the connection must have been made through the callback's proxy");
+    }
+
+    @Test
+    void shouldLayerTlsOnATlsSocketFromTheCallback() throws Exception {
+        // The callback returns an SSLSocket, so two independent TLS sessions are in play: the callback's own session
+        // with the intermediary, and the driver's session with the KMS host carried inside it.
+        ConnectProxy proxy = new ConnectProxy(true);
+
+        SSLSocket socket = connect(proxy.callback(true));
+
+        assertEquals("PONG", exchange(socket, "PING"));
+        assertEquals("PING", kmsServer.received());
+        assertEquals(1, proxy.connectCount());
+    }
+
+    @Test
+    void shouldPassTheProviderAddressAndTimeoutToTheCallback() throws Exception {
+        ConnectProxy proxy = new ConnectProxy(false);
+        AtomicReference<KmsConnectContext> observed = new AtomicReference<>();
+        KmsConnectCallback recording = context -> {
+            observed.set(context);
+            return proxy.callback(false).connect(context);
+        };
+
+        exchange(KmsSocketConnector.connect(clientSslContext(), recording, "aws:myname", kmsServer.address(),
+                TIMEOUT_MILLIS, TIMEOUT_MILLIS), "PING");
+
+        KmsConnectContext context = observed.get();
+        assertNotNull(context);
+        assertEquals("aws:myname", context.getKmsProvider());
+        assertEquals(kmsServer.address(), context.getServerAddress(),
+                "the callback must receive the KMS host address, not the address it connects to");
+        assertEquals(TIMEOUT_MILLIS, context.getTimeoutMillis());
+    }
+
+    @Test
+    void shouldVerifyCertificateAgainstKmsHostRatherThanTheAddressTheCallbackConnectedTo() throws Exception {
+        ConnectProxy proxy = new ConnectProxy(false);
+
+        // "localhost" resolves to the same server, but the KMS host's certificate is issued for the IP address only.
+        // The handshake must therefore fail, proving that hostname verification is performed against the address the
+        // driver was given rather than against whatever the callback connected to.
+        ServerAddress unverifiableAddress = new ServerAddress("localhost", kmsServer.address().getPort());
+
+        assertThrows(SSLHandshakeException.class, () -> KmsSocketConnector.connect(clientSslContext(),
+                proxy.callback(false), "aws", unverifiableAddress, TIMEOUT_MILLIS, TIMEOUT_MILLIS));
+    }
+
+    @Test
+    void shouldPropagateAnIOExceptionFromTheCallback() {
+        IOException failure = new IOException("proxy refused CONNECT");
+
+        IOException thrown = assertThrows(IOException.class, () -> connect(context -> {
+            throw failure;
+        }));
+
+        assertSame(failure, thrown, "an IOException from the callback must be propagated unchanged");
+    }
+
+    @Test
+    void shouldCloseTheCallbackSocketWhenTheHandshakeFails() throws Exception {
+        // A server that accepts and immediately closes, so the KMS handshake over it fails promptly.
+        ServerSocket unresponsive = new ServerSocket(0, 1, loopback());
+        toClose.add(unresponsive);
+        start(() -> {
+            try (Socket accepted = unresponsive.accept()) {
+                assertNotNull(accepted);
+            } catch (IOException e) {
+                // the test is finished with this connection
+            }
+        }, "unresponsive-server");
+
+        AtomicReference<Socket> callbackSocket = new AtomicReference<>();
+        KmsConnectCallback notTunneling = context -> {
+            Socket socket = new Socket();
+            socket.connect(new InetSocketAddress(unresponsive.getInetAddress(), unresponsive.getLocalPort()),
+                    TIMEOUT_MILLIS);
+            socket.setSoTimeout(TIMEOUT_MILLIS);
+            callbackSocket.set(socket);
+            return socket;
+        };
+
+        assertThrows(IOException.class, () -> connect(notTunneling));
+
+        assertTrue(callbackSocket.get().isClosed(),
+                "the socket returned by the callback must be closed when the driver fails to establish TLS over it");
+    }
+
+    private SSLSocket connect(@Nullable final KmsConnectCallback callback) throws Exception {
+        return KmsSocketConnector.connect(clientSslContext(), callback, "aws", kmsServer.address(),
+                TIMEOUT_MILLIS, TIMEOUT_MILLIS);
+    }
+
+    private String exchange(final SSLSocket socket, final String request) throws IOException {
+        try (SSLSocket tls = socket) {
+            tls.getOutputStream().write(request.getBytes(StandardCharsets.UTF_8));
+            tls.getOutputStream().flush();
+            byte[] response = new byte[16];
+            int read = tls.getInputStream().read(response);
+            return new String(response, 0, read, StandardCharsets.UTF_8);
+        }
+    }
+
+    // --- in-process HTTP CONNECT proxy -------------------------------------------------------------------------
+
+    private final class ConnectProxy {
+        private final ServerSocket serverSocket;
+        private volatile String responseStatusLine = "HTTP/1.1 200 Connection Established";
+        private volatile int connectCount;
+
+        ConnectProxy(final boolean useTls) throws Exception {
+            this.serverSocket = useTls
+                    ? serverSslContext().getServerSocketFactory().createServerSocket(0, 1, loopback())
+                    : new ServerSocket(0, 1, loopback());
+            toClose.add(serverSocket);
+            start(this::acceptLoop, "kms-connect-proxy");
+        }
+
+        /**
+         * Returns a callback that tunnels to the KMS host through this proxy using {@code HTTP CONNECT}, which is what
+         * a user of {@link KmsConnectCallback} is expected to implement.
+         */
+        KmsConnectCallback callback(final boolean useTls) {
+            return context -> {
+                Socket socket;
+                try {
+                    socket = useTls ? clientSslContext().getSocketFactory().createSocket() : new Socket();
+                } catch (GeneralSecurityException e) {
+                    throw new IOException("could not create the callback's socket", e);
+                }
+                try {
+                    socket.connect(new InetSocketAddress(CERTIFIED_HOST, serverSocket.getLocalPort()), TIMEOUT_MILLIS);
+                    socket.setSoTimeout(TIMEOUT_MILLIS);
+                    ServerAddress target = context.getServerAddress();
+                    String hostPort = target.getHost() + ":" + target.getPort();
+                    socket.getOutputStream().write(("CONNECT " + hostPort + " HTTP/1.1\r\nHost: " + hostPort
+                            + "\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
+                    socket.getOutputStream().flush();
+                    // One byte at a time, so that no byte of the driver's TLS handshake is consumed.
+                    StringBuilder headers = new StringBuilder();
+                    while (!headers.toString().endsWith("\r\n\r\n")) {
+                        int b = socket.getInputStream().read();
+                        if (b == -1) {
+                            throw new IOException("proxy closed the connection: " + headers);
+                        }
+                        headers.append((char) b);
+                    }
+                    String statusLine = headers.substring(0, headers.indexOf("\r\n"));
+                    if (!statusLine.contains(" 2")) {
+                        throw new IOException("proxy refused the CONNECT request: " + statusLine);
+                    }
+                    return socket;
+                } catch (IOException | RuntimeException e) {
+                    socket.close();
+                    throw e;
+                }
+            };
+        }
+
+        void respondWith(final String statusLine) {
+            this.responseStatusLine = statusLine;
+        }
+
+        int connectCount() {
+            return connectCount;
+        }
+
+        private void acceptLoop() {
+            while (!serverSocket.isClosed()) {
+                try {
+                    Socket client = serverSocket.accept();
+                    toClose.add(client);
+                    handle(client);
+                } catch (IOException e) {
+                    return;
+                }
+            }
+        }
+
+        private void handle(final Socket client) throws IOException {
+            List<String> headers = readHeaders(client.getInputStream());
+            String requestLine = headers.get(0);
+            if (!requestLine.startsWith("CONNECT ") || !responseStatusLine.contains(" 2")) {
+                client.getOutputStream().write((responseStatusLine + "\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
+                client.getOutputStream().flush();
+                return;
+            }
+            String[] hostAndPort = requestLine.split(" ")[1].split(":");
+            Socket upstream = new Socket();
+            upstream.connect(new InetSocketAddress(hostAndPort[0], Integer.parseInt(hostAndPort[1])),
+                    TIMEOUT_MILLIS);
+            toClose.add(upstream);
+            connectCount++;
+            client.getOutputStream().write((responseStatusLine + "\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
+            client.getOutputStream().flush();
+            // From here the proxy is a blind pipe, which is what makes end-to-end TLS with the KMS host possible.
+            start(() -> pipe(client, upstream), "kms-proxy-pipe-out");
+            start(() -> pipe(upstream, client), "kms-proxy-pipe-in");
+        }
+
+        private List<String> readHeaders(final InputStream inputStream) throws IOException {
+            StringBuilder raw = new StringBuilder();
+            while (!raw.toString().endsWith("\r\n\r\n")) {
+                int b = inputStream.read();
+                if (b == -1) {
+                    throw new IOException("client closed before completing the request: " + raw);
+                }
+                raw.append((char) b);
+            }
+            List<String> headers = new ArrayList<>();
+            for (String line : raw.toString().split("\r\n")) {
+                if (!line.isEmpty()) {
+                    headers.add(line);
+                }
+            }
+            return headers;
+        }
+
+        private void pipe(final Socket from, final Socket to) {
+            byte[] buffer = new byte[4096];
+            try {
+                InputStream in = from.getInputStream();
+                OutputStream out = to.getOutputStream();
+                int read;
+                while ((read = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, read);
+                    out.flush();
+                }
+            } catch (IOException e) {
+                // the test is finished with this connection
+            }
+        }
+    }
+
+    // --- in-process stand-in for the KMS host -----------------------------------------------------------------
+
+    private final class FakeKmsServer {
+        private final SSLServerSocket serverSocket;
+        private final AtomicReference<String> received = new AtomicReference<>();
+
+        FakeKmsServer() throws Exception {
+            serverSocket = (SSLServerSocket) serverSslContext().getServerSocketFactory()
+                    .createServerSocket(0, 1, loopback());
+            toClose.add(serverSocket);
+            start(this::acceptLoop, "fake-kms-server");
+        }
+
+        ServerAddress address() {
+            return new ServerAddress(CERTIFIED_HOST, serverSocket.getLocalPort());
+        }
+
+        String received() {
+            return received.get();
+        }
+
+        private void acceptLoop() {
+            while (!serverSocket.isClosed()) {
+                try (SSLSocket accepted = (SSLSocket) serverSocket.accept()) {
+                    byte[] buffer = new byte[16];
+                    int read = accepted.getInputStream().read(buffer);
+                    if (read > 0) {
+                        received.set(new String(buffer, 0, read, StandardCharsets.UTF_8));
+                        accepted.getOutputStream().write("PONG".getBytes(StandardCharsets.UTF_8));
+                        accepted.getOutputStream().flush();
+                    }
+                } catch (IOException e) {
+                    return;
+                }
+            }
+        }
+    }
+
+    // --- shared helpers ---------------------------------------------------------------------------------------
+
+    private void start(final Runnable body, final String name) {
+        Thread thread = new Thread(body, name);
+        thread.setDaemon(true);
+        threads.add(thread);
+        thread.start();
+    }
+
+    private static InetAddress loopback() {
+        return InetAddress.getLoopbackAddress();
+    }
+
+    @BeforeAll
+    static void generateKeyStore() throws IOException, InterruptedException {
+        keyStoreDir = Files.createTempDirectory("kms-tunnel-test");
+        keyStorePath = keyStoreDir.resolve("kms-tunnel-test.p12");
+        String executable = System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")
+                ? "keytool.exe" : "keytool";
+        Path keytool = Paths.get(System.getProperty("java.home"), "bin", executable);
+
+        Process process = new ProcessBuilder(keytool.toString(),
+                "-genkeypair", "-alias", "kms", "-keyalg", "RSA", "-keysize", "2048", "-validity", "1",
+                "-storetype", "PKCS12", "-keystore", keyStorePath.toString(),
+                "-storepass", new String(KEYSTORE_PASSWORD), "-keypass", new String(KEYSTORE_PASSWORD),
+                "-dname", "CN=127.0.0.1", "-ext", "SAN=IP:127.0.0.1")
+                .redirectErrorStream(true)
+                .start();
+        String output;
+        try (InputStream in = process.getInputStream()) {
+            ByteArrayOutputStream captured = new ByteArrayOutputStream();
+            byte[] buffer = new byte[512];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                captured.write(buffer, 0, read);
+            }
+            output = new String(captured.toByteArray(), StandardCharsets.UTF_8);
+        }
+        assertTrue(process.waitFor(60, TimeUnit.SECONDS), "keytool did not finish in time");
+        assertEquals(0, process.exitValue(), () -> "keytool failed: " + output);
+    }
+
+    @AfterAll
+    static void deleteKeyStore() throws IOException {
+        Files.deleteIfExists(keyStorePath);
+        Files.deleteIfExists(keyStoreDir);
+    }
+
+    private static KeyStore keyStore() throws IOException, GeneralSecurityException {
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        try (InputStream in = Files.newInputStream(keyStorePath)) {
+            keyStore.load(in, KEYSTORE_PASSWORD);
+        }
+        return keyStore;
+    }
+
+    private static SSLContext serverSslContext() throws IOException, GeneralSecurityException {
+        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore(), KEYSTORE_PASSWORD);
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
+        return sslContext;
+    }
+
+    private static SSLContext clientSslContext() throws IOException, GeneralSecurityException {
+        TrustManagerFactory trustManagerFactory =
+                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init(keyStore());
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
+        return sslContext;
+    }
+}

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypts.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypts.java
@@ -18,11 +18,13 @@ package com.mongodb.reactivestreams.client.internal.crypt;
 
 import com.mongodb.AutoEncryptionSettings;
 import com.mongodb.ClientEncryptionSettings;
+import com.mongodb.KmsConnectCallback;
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoNamespace;
 import com.mongodb.internal.crypt.capi.MongoCrypt;
 import com.mongodb.internal.crypt.capi.MongoCrypts;
+import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
 
@@ -41,6 +43,7 @@ public final class Crypts {
     }
 
     public static Crypt createCrypt(final MongoClientSettings mongoClientSettings, final AutoEncryptionSettings autoEncryptionSettings) {
+        assertKmsConnectCallbackNotConfigured(autoEncryptionSettings.getKmsConnectCallback());
         MongoClient sharedInternalClient = null;
         MongoClientSettings keyVaultMongoClientSettings = autoEncryptionSettings.getKeyVaultMongoClientSettings();
         if (keyVaultMongoClientSettings == null || !autoEncryptionSettings.isBypassAutoEncryption()) {
@@ -67,12 +70,26 @@ public final class Crypts {
     }
 
     public static Crypt create(final MongoClient keyVaultClient, final ClientEncryptionSettings settings) {
+        assertKmsConnectCallbackNotConfigured(settings.getKmsConnectCallback());
         return new Crypt(MongoCrypts.create(createMongoCryptOptions(settings)),
                 createKeyRetriever(keyVaultClient, settings.getKeyVaultNamespace()),
                 createKeyManagementService(settings.getKmsProviderSslContextMap()),
                 settings.getKmsProviders(),
                 settings.getKmsProviderPropertySuppliers()
         );
+    }
+
+    /**
+     * A {@link KmsConnectCallback} returns a {@link java.net.Socket}, which offers only blocking I/O and cannot be
+     * adapted to the non-blocking machinery this driver uses: a socket connected to an intermediary over TLS is never
+     * backed by a {@link java.nio.channels.SocketChannel}. Fail rather than silently connecting to KMS hosts directly,
+     * which mirrors how a proxy configured for connections to a MongoDB server is rejected in
+     * {@link MongoClients#create(MongoClientSettings, com.mongodb.MongoDriverInformation)}.
+     */
+    private static void assertKmsConnectCallbackNotConfigured(@Nullable final KmsConnectCallback kmsConnectCallback) {
+        if (kmsConnectCallback != null) {
+            throw new MongoClientException("kmsConnectCallback is not supported for reactive clients");
+        }
     }
 
     private static KeyRetriever createKeyRetriever(final MongoClient keyVaultClient,

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/crypt/CryptsKmsConnectCallbackNotSupportedTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/crypt/CryptsKmsConnectCallbackNotSupportedTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client.internal.crypt;
+
+import com.mongodb.AutoEncryptionSettings;
+import com.mongodb.ClientEncryptionSettings;
+import com.mongodb.KmsConnectCallback;
+import com.mongodb.MongoClientException;
+import com.mongodb.MongoClientSettings;
+import org.junit.jupiter.api.Test;
+
+import java.net.Socket;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link KmsConnectCallback} is implemented only for the synchronous driver, so configuring one for a reactive client
+ * must fail rather than silently connecting to KMS hosts directly.
+ */
+final class CryptsKmsConnectCallbackNotSupportedTest {
+
+    private static final KmsConnectCallback CALLBACK = context -> new Socket();
+
+    @Test
+    void shouldRejectACallbackOnAutoEncryptionSettings() {
+        AutoEncryptionSettings settings = AutoEncryptionSettings.builder()
+                .keyVaultNamespace("keyvault.datakeys")
+                .kmsProviders(new HashMap<>())
+                .kmsConnectCallback(CALLBACK)
+                .build();
+
+        MongoClientException e = assertThrows(MongoClientException.class,
+                () -> Crypts.createCrypt(MongoClientSettings.builder().build(), settings));
+        assertTrue(e.getMessage().contains("not supported for reactive clients"),
+                () -> "unexpected message: " + e.getMessage());
+    }
+
+    @Test
+    void shouldRejectACallbackOnClientEncryptionSettings() {
+        ClientEncryptionSettings settings = ClientEncryptionSettings.builder()
+                .keyVaultMongoClientSettings(MongoClientSettings.builder().build())
+                .keyVaultNamespace("keyvault.datakeys")
+                .kmsProviders(new HashMap<>())
+                .kmsConnectCallback(CALLBACK)
+                .build();
+
+        MongoClientException e = assertThrows(MongoClientException.class, () -> Crypts.create(null, settings));
+        assertTrue(e.getMessage().contains("not supported for reactive clients"),
+                () -> "unexpected message: " + e.getMessage());
+    }
+
+    @Test
+    void shouldNotRejectSettingsWithoutACallback() {
+        ClientEncryptionSettings settings = ClientEncryptionSettings.builder()
+                .keyVaultMongoClientSettings(MongoClientSettings.builder().build())
+                .keyVaultNamespace("keyvault.datakeys")
+                .kmsProviders(new HashMap<>())
+                .build();
+
+        // Without a callback the guard must not fire; construction then fails for an unrelated reason, which is not a
+        // MongoClientException about callback support.
+        Throwable thrown = assertThrows(Throwable.class, () -> Crypts.create(null, settings));
+        assertTrue(thrown.getMessage() == null || !thrown.getMessage().contains("not supported for reactive clients"),
+                () -> "the callback guard fired unexpectedly: " + thrown.getMessage());
+    }
+}

--- a/driver-sync/src/main/com/mongodb/client/internal/Crypts.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Crypts.java
@@ -18,12 +18,14 @@ package com.mongodb.client.internal;
 
 import com.mongodb.AutoEncryptionSettings;
 import com.mongodb.ClientEncryptionSettings;
+import com.mongodb.KmsConnectCallback;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.internal.crypt.capi.MongoCrypt;
 import com.mongodb.internal.crypt.capi.MongoCrypts;
+import com.mongodb.lang.Nullable;
 
 import javax.net.ssl.SSLContext;
 import java.util.Map;
@@ -51,7 +53,7 @@ public final class Crypts {
         return new Crypt(
                 mongoCrypt,
                 createKeyRetriever(keyVaultClient, settings.getKeyVaultNamespace()),
-                createKeyManagementService(settings.getKmsProviderSslContextMap()),
+                createKeyManagementService(settings.getKmsProviderSslContextMap(), settings.getKmsConnectCallback()),
                 settings.getKmsProviders(),
                 settings.getKmsProviderPropertySuppliers(),
                 settings.isBypassAutoEncryption(),
@@ -63,7 +65,7 @@ public final class Crypts {
     static Crypt create(final MongoClient keyVaultClient, final ClientEncryptionSettings settings) {
         return new Crypt(MongoCrypts.create(createMongoCryptOptions(settings)),
                 createKeyRetriever(keyVaultClient, settings.getKeyVaultNamespace()),
-                createKeyManagementService(settings.getKmsProviderSslContextMap()),
+                createKeyManagementService(settings.getKmsProviderSslContextMap(), settings.getKmsConnectCallback()),
                 settings.getKmsProviders(),
                 settings.getKmsProviderPropertySuppliers()
         );
@@ -73,8 +75,9 @@ public final class Crypts {
         return new KeyRetriever(keyVaultClient, new MongoNamespace(keyVaultNamespaceString));
     }
 
-    private static KeyManagementService createKeyManagementService(final Map<String, SSLContext> kmsProviderSslContextMap) {
-        return new KeyManagementService(kmsProviderSslContextMap, 10000);
+    private static KeyManagementService createKeyManagementService(final Map<String, SSLContext> kmsProviderSslContextMap,
+            @Nullable final KmsConnectCallback kmsConnectCallback) {
+        return new KeyManagementService(kmsProviderSslContextMap, kmsConnectCallback, 10000);
     }
 
     private Crypts() {

--- a/driver-sync/src/main/com/mongodb/client/internal/KeyManagementService.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/KeyManagementService.java
@@ -16,25 +16,21 @@
 
 package com.mongodb.client.internal;
 
+import com.mongodb.KmsConnectCallback;
 import com.mongodb.ServerAddress;
 import com.mongodb.internal.TimeoutContext;
-import com.mongodb.internal.connection.SslHelper;
+import com.mongodb.internal.capi.KmsSocketConnector;
 import com.mongodb.internal.diagnostics.logging.Logger;
 import com.mongodb.internal.diagnostics.logging.Loggers;
 import com.mongodb.internal.time.Timeout;
 import com.mongodb.lang.Nullable;
 import com.mongodb.lang.NonNull;
 
-import javax.net.SocketFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
@@ -48,10 +44,14 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 class KeyManagementService {
     private static final Logger LOGGER = Loggers.getLogger("client");
     private final Map<String, SSLContext> kmsProviderSslContextMap;
+    @Nullable
+    private final KmsConnectCallback kmsConnectCallback;
     private final int timeoutMillis;
 
-    KeyManagementService(final Map<String, SSLContext> kmsProviderSslContextMap, final int timeoutMillis) {
+    KeyManagementService(final Map<String, SSLContext> kmsProviderSslContextMap,
+            @Nullable final KmsConnectCallback kmsConnectCallback, final int timeoutMillis) {
         this.kmsProviderSslContextMap = notNull("kmsProviderSslContextMap", kmsProviderSslContextMap);
+        this.kmsConnectCallback = kmsConnectCallback;
         this.timeoutMillis = timeoutMillis;
     }
 
@@ -61,18 +61,15 @@ class KeyManagementService {
         LOGGER.info("Connecting to KMS server at " + serverAddress);
         SSLContext sslContext = kmsProviderSslContextMap.get(kmsProvider);
 
-        SocketFactory sslSocketFactory = sslContext == null
-                    ? SSLSocketFactory.getDefault() : sslContext.getSocketFactory();
-        SSLSocket socket = (SSLSocket) sslSocketFactory.createSocket();
-        enableHostNameVerification(socket);
+        SSLSocket socket = KmsSocketConnector.connect(sslContext, kmsConnectCallback, kmsProvider, serverAddress,
+                timeoutMillis, remainingMillis(operationTimeout));
 
-        try {
-            socket.setSoTimeout(timeoutMillis);
-            socket.connect(new InetSocketAddress(InetAddress.getByName(serverAddress.getHost()), serverAddress.getPort()), timeoutMillis);
-        } catch (IOException e) {
+        // A KmsConnectCallback performs blocking I/O and may overrun the deadline it was given, which cannot be
+        // preempted. Re-check before issuing a request whose time budget is already spent.
+        Timeout.nullAsInfinite(operationTimeout).onExpired(() -> {
             closeSocket(socket);
-            throw e;
-        }
+            TimeoutContext.throwMongoTimeoutException("Connecting to KMS server exceeded the timeout limit.");
+        });
 
         try {
             OutputStream outputStream = socket.getOutputStream();
@@ -94,13 +91,20 @@ class KeyManagementService {
         }
     }
 
-    private void enableHostNameVerification(final SSLSocket socket) {
-        SSLParameters sslParameters = socket.getSSLParameters();
-        if (sslParameters == null) {
-            sslParameters = new SSLParameters();
-        }
-        SslHelper.enableHostNameVerification(sslParameters);
-        socket.setSSLParameters(sslParameters);
+    /**
+     * Determines the time available for reaching the KMS server, which the specification requires to be the time
+     * remaining in the operation when CSOT is in use.
+     *
+     * <p>Visible for testing.</p>
+     *
+     * @return the remaining time available for connecting to the KMS server, in milliseconds, never larger than the
+     * configured connect timeout.
+     */
+    long remainingMillis(@Nullable final Timeout operationTimeout) {
+        return Timeout.nullAsInfinite(operationTimeout).call(MILLISECONDS,
+                () -> (long) timeoutMillis,
+                (ms) -> Math.min(ms, timeoutMillis),
+                () -> TimeoutContext.throwMongoTimeoutException("Connecting to KMS server exceeded the timeout limit."));
     }
 
     private void closeSocket(final Socket socket) {

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionKmsConnectCallbackProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionKmsConnectCallbackProseTest.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import com.mongodb.AutoEncryptionSettings;
+import com.mongodb.ClientEncryptionSettings;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.KmsConnectCallback;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.vault.DataKeyOptions;
+import com.mongodb.client.vault.ClientEncryption;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonBinary;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.mongodb.ClusterFixture.isClientSideEncryptionTest;
+import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Prose test 28, "KMS Connect Callback".
+ *
+ * <p>All cases require real AWS KMS credentials and are skipped when they are not available. The KMS HTTP proxy is
+ * started by {@code drivers-evergreen-tools}: {@code .evergreen/csfle/start-servers.sh} runs {@code kms_http_proxy.py}
+ * on port 9004 in plain HTTP mode and on port 9005 in HTTPS mode. Cases are skipped when the proxy is unreachable, so
+ * that this test does not fail when run outside that environment.</p>
+ *
+ * <p>Case 6, "Retry", is not implemented: it is to be skipped by drivers that do not implement DRIVERS-1541, and this
+ * driver does not retry KMS requests.</p>
+ *
+ * @see <a href="https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#28-kms-connect-callback">
+ * Prose test 28</a>
+ */
+public abstract class AbstractClientSideEncryptionKmsConnectCallbackProseTest {
+
+    private static final String PROXY_HOST = "127.0.0.1";
+    private static final int HTTP_PROXY_PORT = 9004;
+    private static final int HTTPS_PROXY_PORT = 9005;
+
+    private static final String KEY_VAULT_NAMESPACE = "keyvault.datakeys";
+    private static final String MASTER_KEY = "{"
+            + "region: \"us-east-1\", "
+            + "key: \"arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0\"}";
+
+    private static final Pattern CONNECT_COUNT_PATTERN = Pattern.compile("connect_count (\\d+)");
+
+    protected abstract ClientEncryption createClientEncryption(ClientEncryptionSettings settings);
+
+    protected abstract MongoClient createMongoClient(MongoClientSettings settings);
+
+    @BeforeEach
+    void requireAwsCredentials() {
+        assumeTrue(isClientSideEncryptionTest(), "Requires AWS KMS credentials");
+    }
+
+    @Test
+    @DisplayName("Case 1: plain HTTP proxy")
+    void testPlainHttpProxy() throws IOException {
+        assumeProxyIsRunning(false);
+        resetMetrics(false);
+
+        try (ClientEncryption clientEncryption = createClientEncryption(clientEncryptionSettingsBuilder(null)
+                .kmsConnectCallback(proxyConnectCallback(false, null))
+                .build())) {
+            assertNotNull(createDataKey(clientEncryption));
+        }
+
+        assertTrue(getConnectCount(false) >= 1, "expected the KMS request to be routed through the proxy");
+    }
+
+    @Test
+    @DisplayName("Case 2: HTTPS proxy")
+    void testHttpsProxy() throws IOException {
+        assumeTrue(caFile() != null, "Requires the proxy's CA file, e.g. $DRIVERS_TOOLS/.evergreen/x509gen/ca.pem");
+        assumeProxyIsRunning(true);
+        resetMetrics(true);
+
+        // Two independent TLS layers are in play here: the driver's connection to the proxy, verified against the
+        // proxy's CA, and its connection to the KMS host, carried end-to-end through the CONNECT tunnel and verified
+        // against the real KMS host's certificate. Creating the data key confirms the driver verified the KMS host's
+        // identity rather than the proxy's.
+        try (ClientEncryption clientEncryption = createClientEncryption(clientEncryptionSettingsBuilder(null)
+                .kmsConnectCallback(proxyConnectCallback(true, null))
+                .build())) {
+            assertNotNull(createDataKey(clientEncryption));
+        }
+
+        assertTrue(getConnectCount(true) >= 1, "expected the KMS request to be routed through the proxy");
+    }
+
+    @Test
+    @DisplayName("Case 3: full auto encryption pipeline via proxy")
+    void testAutoEncryptionPipelineViaProxy() throws IOException {
+        assumeProxyIsRunning(false);
+
+        try (MongoClient client = createMongoClient(getMongoClientSettingsBuilder().build())) {
+            client.getDatabase("keyvault").getCollection("datakeys").drop();
+            client.getDatabase("db").getCollection("coll").drop();
+
+            BsonBinary dataKeyId;
+            try (ClientEncryption clientEncryption = createClientEncryption(clientEncryptionSettingsBuilder(null)
+                    .kmsConnectCallback(proxyConnectCallback(false, null))
+                    .build())) {
+                dataKeyId = createDataKey(clientEncryption);
+                assertNotNull(dataKeyId);
+            }
+
+            Map<String, BsonDocument> schemaMap = new HashMap<>();
+            schemaMap.put("db.coll", schemaForDataKey(dataKeyId));
+
+            resetMetrics(false);
+
+            AutoEncryptionSettings autoEncryptionSettings = AutoEncryptionSettings.builder()
+                    .keyVaultNamespace(KEY_VAULT_NAMESPACE)
+                    .kmsProviders(awsKmsProviders())
+                    .schemaMap(schemaMap)
+                    .kmsConnectCallback(proxyConnectCallback(false, null))
+                    .build();
+
+            try (MongoClient encryptedClient = createMongoClient(getMongoClientSettingsBuilder()
+                    .autoEncryptionSettings(autoEncryptionSettings)
+                    .build())) {
+                MongoCollection<Document> encryptedColl = encryptedClient.getDatabase("db").getCollection("coll");
+                encryptedColl.insertOne(new Document("_id", 1).append("encrypted_string", "hello"));
+
+                Document decrypted = encryptedColl.find(Filters.eq("_id", 1)).first();
+                assertNotNull(decrypted);
+                assertEquals("hello", decrypted.get("encrypted_string"));
+            }
+
+            // read with the unencrypted client to confirm the value is stored encrypted
+            Document stored = client.getDatabase("db").getCollection("coll").find(Filters.eq("_id", 1)).first();
+            assertNotNull(stored);
+            assertInstanceOf(org.bson.types.Binary.class, stored.get("encrypted_string"));
+        }
+
+        // only one KMS request is expected, since the decrypted key is cached
+        assertTrue(getConnectCount(false) >= 1, "expected KMS requests to be routed through the proxy");
+    }
+
+    @Test
+    @DisplayName("Case 4: Error")
+    void testCallbackError() {
+        String failureMessage = "Proxy refused the CONNECT request";
+        KmsConnectCallback failingCallback = context -> {
+            throw new IOException(failureMessage);
+        };
+
+        try (ClientEncryption clientEncryption = createClientEncryption(clientEncryptionSettingsBuilder(null)
+                .kmsConnectCallback(failingCallback)
+                .build())) {
+            RuntimeException e = assertThrows(RuntimeException.class, () -> createDataKey(clientEncryption));
+            assertTrue(causeChainContains(e, failureMessage),
+                    () -> "expected the callback's failure to be reported, but got: " + e);
+        }
+    }
+
+    @Test
+    @DisplayName("Case 5: operation timeout is honored through the proxy")
+    void testTimeoutThroughProxy() throws IOException {
+        // The spec asserts that the callback receives a non-zero timeout. With declarative configuration there is no
+        // callback to observe, so this instead asserts that an operation with a timeout configured still succeeds
+        // through the proxy, exercising the same CSOT plumbing.
+        assumeProxyIsRunning(false);
+
+        try (ClientEncryption clientEncryption = createClientEncryption(clientEncryptionSettingsBuilder(1000L)
+                .kmsConnectCallback(proxyConnectCallback(false, null))
+                .build())) {
+            assertNotNull(createDataKey(clientEncryption));
+        }
+    }
+
+    /**
+     * Returns a callback that tunnels to the KMS host through the proxy using HTTP CONNECT, as described in the Setup
+     * section of prose test 28:
+     * <ol>
+     *     <li>Accept {@code (host, port)} from the driver.</li>
+     *     <li>Open a connection to the proxy — plain TCP on port 9004, or TLS verified with {@code ca.pem} on 9005.</li>
+     *     <li>Send {@code CONNECT <host>:<port> HTTP/1.1\r\nHost: <host>:<port>\r\n\r\n}.</li>
+     *     <li>Read the response and verify it begins with {@code HTTP/1.1 200}.</li>
+     *     <li>Return the socket, over which the driver negotiates TLS with the KMS host.</li>
+     * </ol>
+     */
+    private KmsConnectCallback proxyConnectCallback(final boolean useTls, @Nullable final AtomicLong observedTimeout) {
+        return context -> {
+            if (observedTimeout != null) {
+                observedTimeout.set(context.getTimeoutMillis());
+            }
+            int timeout = (int) Math.min(context.getTimeoutMillis(), Integer.MAX_VALUE);
+            Socket socket = useTls
+                    ? proxySslContext().getSocketFactory().createSocket()
+                    : new Socket();
+            try {
+                socket.connect(new InetSocketAddress(PROXY_HOST, useTls ? HTTPS_PROXY_PORT : HTTP_PROXY_PORT), timeout);
+                socket.setSoTimeout(timeout);
+                String target = context.getServerAddress().getHost() + ":" + context.getServerAddress().getPort();
+                socket.getOutputStream().write(("CONNECT " + target + " HTTP/1.1\r\nHost: " + target + "\r\n\r\n")
+                        .getBytes(StandardCharsets.US_ASCII));
+                socket.getOutputStream().flush();
+                // One byte at a time, so that no byte of the driver's TLS handshake is consumed.
+                StringBuilder headers = new StringBuilder();
+                while (!headers.toString().endsWith("\r\n\r\n")) {
+                    int b = socket.getInputStream().read();
+                    if (b == -1) {
+                        throw new IOException("Proxy closed the connection before completing CONNECT: " + headers);
+                    }
+                    headers.append((char) b);
+                }
+                String statusLine = headers.substring(0, headers.indexOf("\r\n"));
+                if (!statusLine.startsWith("HTTP/1.1 200")) {
+                    throw new IOException("Proxy refused the CONNECT request: " + statusLine);
+                }
+                return socket;
+            } catch (IOException | RuntimeException e) {
+                socket.close();
+                throw e;
+            }
+        };
+    }
+
+    private static boolean causeChainContains(final Throwable throwable, final String message) {
+        for (Throwable t = throwable; t != null; t = t.getCause()) {
+            if (t.getMessage() != null && t.getMessage().contains(message)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private ClientEncryptionSettings.Builder clientEncryptionSettingsBuilder(@Nullable final Long timeoutMS) {
+        MongoClientSettings.Builder keyVaultSettingsBuilder = getMongoClientSettingsBuilder();
+        if (timeoutMS != null) {
+            keyVaultSettingsBuilder.timeout(timeoutMS, MILLISECONDS);
+        }
+        ClientEncryptionSettings.Builder builder = ClientEncryptionSettings.builder()
+                .keyVaultMongoClientSettings(keyVaultSettingsBuilder.build())
+                .keyVaultNamespace(KEY_VAULT_NAMESPACE)
+                .kmsProviders(awsKmsProviders());
+        if (timeoutMS != null) {
+            builder.timeout(timeoutMS, MILLISECONDS);
+        }
+        return builder;
+    }
+
+    private static Map<String, Map<String, Object>> awsKmsProviders() {
+        Map<String, Object> aws = new HashMap<>();
+        aws.put("accessKeyId", System.getenv("AWS_ACCESS_KEY_ID"));
+        aws.put("secretAccessKey", System.getenv("AWS_SECRET_ACCESS_KEY"));
+        Map<String, Map<String, Object>> kmsProviders = new HashMap<>();
+        kmsProviders.put("aws", aws);
+        return kmsProviders;
+    }
+
+    private static BsonBinary createDataKey(final ClientEncryption clientEncryption) {
+        return clientEncryption.createDataKey("aws", new DataKeyOptions().masterKey(BsonDocument.parse(MASTER_KEY)));
+    }
+
+    private static BsonDocument schemaForDataKey(final BsonBinary dataKeyId) {
+        String base64DataKeyId = Base64.getEncoder().encodeToString(dataKeyId.getData());
+        return BsonDocument.parse("{"
+                + "  bsonType: \"object\","
+                + "  properties: {"
+                + "    encrypted_string: {"
+                + "      encrypt: {"
+                + "        keyId: [{\"$binary\": {\"base64\": \"" + base64DataKeyId + "\", \"subType\": \"04\"}}],"
+                + "        bsonType: \"string\","
+                + "        algorithm: \"AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic\""
+                + "      }"
+                + "    }"
+                + "  }"
+                + "}");
+    }
+
+    // --- the proxy's control endpoints -------------------------------------------------------------------------
+
+    private void assumeProxyIsRunning(final boolean useTls) {
+        try {
+            getConnectCount(useTls);
+        } catch (IOException e) {
+            assumeTrue(false, "KMS HTTP proxy is not running on port "
+                    + (useTls ? HTTPS_PROXY_PORT : HTTP_PROXY_PORT) + ": " + e.getMessage());
+        }
+    }
+
+    private void resetMetrics(final boolean useTls) throws IOException {
+        readControlResponse("/reset", "POST", useTls);
+    }
+
+    private int getConnectCount(final boolean useTls) throws IOException {
+        String body = readControlResponse("/metrics", "GET", useTls);
+        Matcher matcher = CONNECT_COUNT_PATTERN.matcher(body);
+        if (!matcher.find()) {
+            throw new IOException("Could not find connect_count in the proxy's metrics response: " + body);
+        }
+        return Integer.parseInt(matcher.group(1));
+    }
+
+    private String readControlResponse(final String path, final String method, final boolean useTls) throws IOException {
+        int port = useTls ? HTTPS_PROXY_PORT : HTTP_PROXY_PORT;
+        URL url = new URL((useTls ? "https" : "http") + "://" + PROXY_HOST + ":" + port + path);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        if (useTls) {
+            HttpsURLConnection httpsConnection = (HttpsURLConnection) connection;
+            httpsConnection.setSSLSocketFactory(proxySslContext().getSocketFactory());
+            // The proxy's certificate is verified against its CA above. Its subject does not necessarily match the
+            // loopback address that the control endpoints are reached on, which is immaterial for these tests.
+            httpsConnection.setHostnameVerifier((hostname, session) -> PROXY_HOST.equals(hostname));
+        }
+        connection.setRequestMethod(method);
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+        try (InputStream inputStream = connection.getInputStream()) {
+            ByteArrayOutputStream body = new ByteArrayOutputStream();
+            byte[] buffer = new byte[512];
+            int read;
+            while ((read = inputStream.read(buffer)) != -1) {
+                body.write(buffer, 0, read);
+            }
+            return new String(body.toByteArray(), StandardCharsets.UTF_8);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    // --- the proxy's CA ----------------------------------------------------------------------------------------
+
+    private static volatile SSLContext proxySslContext;
+
+    private static SSLContext proxySslContext() {
+        SSLContext result = proxySslContext;
+        if (result == null) {
+            synchronized (AbstractClientSideEncryptionKmsConnectCallbackProseTest.class) {
+                result = proxySslContext;
+                if (result == null) {
+                    result = buildProxySslContext();
+                    proxySslContext = result;
+                }
+            }
+        }
+        return result;
+    }
+
+    private static SSLContext buildProxySslContext() {
+        String caFile = caFile();
+        assertNotNull(caFile, "the proxy's CA file could not be located");
+        try (InputStream caStream = Files.newInputStream(Paths.get(caFile))) {
+            X509Certificate ca = (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(caStream);
+            KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            trustStore.load(null, null);
+            trustStore.setCertificateEntry("csfle-proxy-ca", ca);
+            TrustManagerFactory trustManagerFactory =
+                    TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(trustStore);
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
+            return sslContext;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("Could not build an SSLContext trusting the proxy's CA", e);
+        }
+    }
+
+    /**
+     * @return the path to the CA certificate that signed the HTTPS proxy's certificate, or null if it cannot be found,
+     * in which case the HTTPS proxy case is skipped.
+     */
+    @Nullable
+    private static String caFile() {
+        String caFile = System.getProperty("org.mongodb.test.csfle.tls.ca.file");
+        if (caFile == null) {
+            caFile = System.getenv("CSFLE_TLS_CA_FILE");
+        }
+        if (caFile == null) {
+            String driversTools = System.getenv("DRIVERS_TOOLS");
+            if (driversTools != null) {
+                caFile = driversTools + "/.evergreen/x509gen/ca.pem";
+            }
+        }
+        return caFile != null && new File(caFile).isFile() ? caFile : null;
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionKmsConnectCallbackProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionKmsConnectCallbackProseTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import com.mongodb.ClientEncryptionSettings;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.vault.ClientEncryption;
+import com.mongodb.client.vault.ClientEncryptions;
+
+public class ClientSideEncryptionKmsConnectCallbackProseTest extends AbstractClientSideEncryptionKmsConnectCallbackProseTest {
+    @Override
+    protected ClientEncryption createClientEncryption(final ClientEncryptionSettings settings) {
+        return ClientEncryptions.create(settings);
+    }
+
+    @Override
+    protected MongoClient createMongoClient(final MongoClientSettings settings) {
+        return MongoClients.create(settings);
+    }
+}

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/KeyManagementServiceTest.java
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/KeyManagementServiceTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.internal;
+
+import com.mongodb.MongoOperationTimeoutException;
+import com.mongodb.internal.time.Timeout;
+import org.junit.jupiter.api.Test;
+
+import static com.mongodb.internal.time.Timeout.ZeroSemantics.ZERO_DURATION_MEANS_EXPIRED;
+import static java.util.Collections.emptyMap;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The specification requires that a driver supporting CSOT pass the remaining {@code timeoutMS} when establishing a
+ * connection to a KMS host. Prose test 28 asserts this by observing a {@code kmsConnectCallback}; this covers the same
+ * requirement directly, including the branches that prose test does not reach.
+ */
+final class KeyManagementServiceTest {
+
+    private static final int CONNECT_TIMEOUT_MILLIS = 10_000;
+
+    private final KeyManagementService keyManagementService =
+            new KeyManagementService(emptyMap(), null, CONNECT_TIMEOUT_MILLIS);
+
+    @Test
+    void shouldUseConfiguredConnectTimeoutWhenNoOperationTimeoutApplies() {
+        assertEquals(CONNECT_TIMEOUT_MILLIS, keyManagementService.remainingMillis(null));
+    }
+
+    @Test
+    void shouldPassRemainingOperationTimeoutWhenItIsShorter() {
+        Timeout operationTimeout = Timeout.expiresIn(500, MILLISECONDS, ZERO_DURATION_MEANS_EXPIRED);
+
+        long remaining = keyManagementService.remainingMillis(operationTimeout);
+
+        assertTrue(remaining > 0 && remaining <= 500,
+                () -> "expected the remaining operation timeout to be passed, but got " + remaining);
+    }
+
+    @Test
+    void shouldNotExceedConfiguredConnectTimeoutWhenOperationTimeoutIsLonger() {
+        Timeout operationTimeout = Timeout.expiresIn(60_000, MILLISECONDS, ZERO_DURATION_MEANS_EXPIRED);
+
+        assertEquals(CONNECT_TIMEOUT_MILLIS, keyManagementService.remainingMillis(operationTimeout));
+    }
+
+    @Test
+    void shouldThrowWhenOperationTimeoutHasExpired() {
+        Timeout expired = Timeout.expiresIn(0, MILLISECONDS, ZERO_DURATION_MEANS_EXPIRED);
+
+        assertThrows(MongoOperationTimeoutException.class, () -> keyManagementService.remainingMillis(expired));
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version=5.10.0-SNAPSHOT
+version=5.11.0-SNAPSHOT
 
 org.gradle.daemon=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en


### PR DESCRIPTION
[Java 6173](https://jira.mongodb.org/browse/JAVA-6173) CSFLE/QE Support for HTTP Proxies
[Spec](https://github.com/mongodb/specifications/blob/92b3c0b9287bfba1b0ec4084300858d05c654f8c/source/client-side-encryption/client-side-encryption.md#kmsconnectcallback) 

This implementation does not support reactive driver because the ProxySetting do not support reactive driver either see [jira.mongodb.org/browse/JAVA-5205](https://jira.mongodb.org/browse/JAVA-5205) 

### Why this does not implement `kmsConnectCallback`
The spec makes the callback optional:

> Drivers are required to support an HTTP proxy but MAY omit `kmsConnectCallback` if they provide an alternative mechanism for proxy support.

This PR takes that route and configures the proxy declaratively instead. Here is why:
The callback returns a `java.net.Socket`, which cannot be turned into a `SocketChannel` (`Socket.getChannel()` is null, and an `SSLSocket` never is one), so `TlsChannel` cannot accept it. 

### API

```java
ClientEncryptionSettings.builder()
    .keyVaultNamespace("keyvault.datakeys")
    .kmsProviders(kmsProviders)
    .proxySettings(ProxySettings.builder()
            .protocol(ProxyProtocol.HTTP)      // or HTTPS to reach the proxy over TLS
            .host("proxy.example.com")
            .port(8080)
            .build())
    .build();
```
I decided to reuse `ProxySetting` even though it was designed for socks5 mongo server communication only, the name itself suggests we should treat it as a regular proxy settings which include http proxy 

## TODO
1. ~I added support for proxy auth https://www.rfc-editor.org/info/rfc9110/#section-11.7.2 though spec doesn't say we need to support it , I dm Kevin~ (looks like the auth was rejected, I left a link to the discussion doc in the jira ticket)
2. Need to follow up with docsp to show code samples

## AI Policy
Claude helped me to implement `KmsSocketConnector` and `HttpProxyTunnel`

