### PR TITLE
Adds overload retry for cursor getMore

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/OverloadStateSuspendedSessionContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OverloadStateSuspendedSessionContext.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.connection;
+
+import com.mongodb.ReadConcern;
+import com.mongodb.internal.session.BaseClientSessionImpl;
+import com.mongodb.internal.session.SessionContext;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
+
+/**
+ * A {@link SessionContext} decorator that suspends session-scoped overload retry policy state by returning
+ * {@link BaseClientSessionImpl.OverloadRetryPolicyState#NO_OP} from {@link #getOverloadRetryPolicyState()}.
+ * Every other method delegates to the wrapped context.
+ *
+ * <p>This class is not part of the public API and may be removed or changed at any time.</p>
+ */
+public final class OverloadStateSuspendedSessionContext implements SessionContext {
+
+    private final SessionContext wrapped;
+
+    public OverloadStateSuspendedSessionContext(final SessionContext wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public boolean hasSession() {
+        return wrapped.hasSession();
+    }
+
+    @Override
+    public boolean isImplicitSession() {
+        return wrapped.isImplicitSession();
+    }
+
+    @Override
+    public BsonDocument getSessionId() {
+        return wrapped.getSessionId();
+    }
+
+    @Override
+    public boolean isCausallyConsistent() {
+        return wrapped.isCausallyConsistent();
+    }
+
+    @Override
+    public long getTransactionNumber() {
+        return wrapped.getTransactionNumber();
+    }
+
+    @Override
+    public long advanceTransactionNumber() {
+        return wrapped.advanceTransactionNumber();
+    }
+
+    @Override
+    public boolean notifyMessageSent() {
+        return wrapped.notifyMessageSent();
+    }
+
+    @Override
+    @Nullable
+    public BsonTimestamp getOperationTime() {
+        return wrapped.getOperationTime();
+    }
+
+    @Override
+    public void advanceOperationTime(@Nullable final BsonTimestamp operationTime) {
+        wrapped.advanceOperationTime(operationTime);
+    }
+
+    @Override
+    @Nullable
+    public BsonDocument getClusterTime() {
+        return wrapped.getClusterTime();
+    }
+
+    @Override
+    public void advanceClusterTime(@Nullable final BsonDocument clusterTime) {
+        wrapped.advanceClusterTime(clusterTime);
+    }
+
+    @Override
+    public boolean isSnapshot() {
+        return wrapped.isSnapshot();
+    }
+
+    @Override
+    public void setSnapshotTimestamp(@Nullable final BsonTimestamp snapshotTimestamp) {
+        wrapped.setSnapshotTimestamp(snapshotTimestamp);
+    }
+
+    @Override
+    @Nullable
+    public BsonTimestamp getSnapshotTimestamp() {
+        return wrapped.getSnapshotTimestamp();
+    }
+
+    @Override
+    public boolean hasActiveTransaction() {
+        return wrapped.hasActiveTransaction();
+    }
+
+    @Override
+    public ReadConcern getReadConcern() {
+        return wrapped.getReadConcern();
+    }
+
+    @Override
+    public void setRecoveryToken(final BsonDocument recoveryToken) {
+        wrapped.setRecoveryToken(recoveryToken);
+    }
+
+    @Override
+    public void clearTransactionContext() {
+        wrapped.clearTransactionContext();
+    }
+
+    @Override
+    public void markSessionDirty() {
+        wrapped.markSessionDirty();
+    }
+
+    @Override
+    public boolean isSessionMarkedDirty() {
+        return wrapped.isSessionMarkedDirty();
+    }
+
+    @Override
+    public BaseClientSessionImpl.OverloadRetryPolicyState getOverloadRetryPolicyState() {
+        return BaseClientSessionImpl.OverloadRetryPolicyState.NO_OP;
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
@@ -250,7 +250,8 @@ class AggregateOperationImpl<T> implements ReadOperationCursor<T> {
         return (result, source, connection, operationContext) ->
                 new CommandBatchCursor<>(getTimeoutMode(), getMaxTimeForCursor(operationContext.getTimeoutContext()), operationContext, new CommandCursor<>(
                         result, batchSize != null ? batchSize : 0,
-                        decoder, comment, source, connection
+                        decoder, comment, source, connection,
+                        retryReads, maxAdaptiveRetriesSetting
                 ));
     }
 
@@ -258,7 +259,8 @@ class AggregateOperationImpl<T> implements ReadOperationCursor<T> {
         return (result, source, connection, operationContext) ->
             new AsyncCommandBatchCursor<>(getTimeoutMode(), getMaxTimeForCursor(operationContext.getTimeoutContext()),
                     operationContext, new AsyncCommandCursor<>(
-                    result, batchSize != null ? batchSize : 0, decoder, comment, source, connection
+                    result, batchSize != null ? batchSize : 0, decoder, comment, source, connection,
+                    retryReads, maxAdaptiveRetriesSetting
             ));
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandCursor.java
@@ -191,14 +191,14 @@ class AsyncCommandCursor<T> implements AsyncCursor<T> {
     }
 
     private void getMore(final ServerCursor cursor, final OperationContext operationContext, final SingleResultCallback<List<T>> callback) {
-        SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY);
-        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
-        AsyncCallbackSupplier<List<T>> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, attemptCallback ->
-                resourceManager.executeWithConnection(operationContext, (connection, wrappedCallback) ->
-                        executeGetMoreCommand(assertNotNull(connection), cursor, operationContext, retryControl, wrappedCallback),
-                        attemptCallback));
-        retryingCommandExecutor.get(callback);
+        resourceManager.executeWithConnection(operationContext, (connection, wrappedCallback) -> {
+            SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
+                    .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY);
+            RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
+            AsyncCallbackSupplier<List<T>> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, attemptCallback ->
+                    executeGetMoreCommand(assertNotNull(connection), cursor, operationContext, retryControl, attemptCallback));
+            retryingCommandExecutor.get(wrappedCallback);
+        }, callback);
     }
 
     private void executeGetMoreCommand(final AsyncConnection connection,

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandCursor.java
@@ -194,11 +194,11 @@ class AsyncCommandCursor<T> implements AsyncCursor<T> {
         SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
                 .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY, true);
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
-        AsyncCallbackSupplier<List<T>> retryingGetMore = decorateWithRetriesAsync(retryControl, operationContext, attemptCallback ->
+        AsyncCallbackSupplier<List<T>> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, attemptCallback ->
                 resourceManager.executeWithConnection(operationContext, (connection, wrappedCallback) ->
                         executeGetMoreCommand(assertNotNull(connection), cursor, operationContext, retryControl, wrappedCallback),
                         attemptCallback));
-        retryingGetMore.get(callback);
+        retryingCommandExecutor.get(callback);
     }
 
     private void executeGetMoreCommand(final AsyncConnection connection,

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandCursor.java
@@ -191,14 +191,14 @@ class AsyncCommandCursor<T> implements AsyncCursor<T> {
     }
 
     private void getMore(final ServerCursor cursor, final OperationContext operationContext, final SingleResultCallback<List<T>> callback) {
-        resourceManager.executeWithConnection(operationContext, (connection, wrappedCallback) -> {
-            SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
-                    .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY);
-            RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
-            AsyncCallbackSupplier<List<T>> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, attemptCallback ->
-                    executeGetMoreCommand(assertNotNull(connection), cursor, operationContext, retryControl, attemptCallback));
-            retryingCommandExecutor.get(wrappedCallback);
-        }, callback);
+        SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY);
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
+        AsyncCallbackSupplier<List<T>> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, attemptCallback ->
+                resourceManager.executeWithConnection(operationContext, (connection, wrappedCallback) ->
+                        executeGetMoreCommand(assertNotNull(connection), cursor, operationContext, retryControl, wrappedCallback),
+                        attemptCallback));
+        retryingCommandExecutor.get(callback);
     }
 
     private void executeGetMoreCommand(final AsyncConnection connection,

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandCursor.java
@@ -192,7 +192,7 @@ class AsyncCommandCursor<T> implements AsyncCursor<T> {
 
     private void getMore(final ServerCursor cursor, final OperationContext operationContext, final SingleResultCallback<List<T>> callback) {
         SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY, true);
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY);
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
         AsyncCallbackSupplier<List<T>> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, attemptCallback ->
                 resourceManager.executeWithConnection(operationContext, (connection, wrappedCallback) ->

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandCursor.java
@@ -30,6 +30,7 @@ import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerType;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.function.AsyncCallbackSupplier;
+import com.mongodb.internal.async.function.RetryControl;
 import com.mongodb.internal.binding.AsyncConnectionSource;
 import com.mongodb.internal.connection.AsyncConnection;
 import com.mongodb.internal.connection.Connection;
@@ -51,6 +52,8 @@ import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.assertions.Assertions.doesNotThrow;
 import static com.mongodb.internal.async.AsyncRunnable.beginAsync;
 import static com.mongodb.internal.async.SingleResultCallback.THEN_DO_NOTHING;
+import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWithRetriesAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.FIRST_BATCH;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.MESSAGE_IF_CLOSED_AS_CURSOR;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.NEXT_BATCH;
@@ -71,6 +74,9 @@ class AsyncCommandCursor<T> implements AsyncCursor<T> {
     private final boolean firstBatchEmpty;
     private final ResourceManager resourceManager;
     private final AtomicBoolean processedInitial = new AtomicBoolean();
+    private final boolean retryReads;
+    @Nullable
+    private final Integer maxAdaptiveRetriesSetting;
     private int batchSize;
     private volatile CommandCursorResult<T> commandCursorResult;
 
@@ -80,7 +86,9 @@ class AsyncCommandCursor<T> implements AsyncCursor<T> {
             final Decoder<T> decoder,
             @Nullable final BsonValue comment,
             final AsyncConnectionSource connectionSource,
-            final AsyncConnection connection) {
+            final AsyncConnection connection,
+            final boolean retryReads,
+            @Nullable final Integer maxAdaptiveRetriesSetting) {
         ConnectionDescription connectionDescription = connection.getDescription();
         this.commandCursorResult = toCommandCursorResult(connectionDescription.getServerAddress(), FIRST_BATCH, commandCursorDocument);
         this.namespace = commandCursorResult.getNamespace();
@@ -92,6 +100,8 @@ class AsyncCommandCursor<T> implements AsyncCursor<T> {
         AsyncConnection connectionToPin = connectionSource.getServerDescription().getType() == ServerType.LOAD_BALANCER
                 ? connection : null;
         resourceManager = new ResourceManager(namespace, connectionSource, connectionToPin, commandCursorResult.getServerCursor());
+        this.retryReads = retryReads;
+        this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
     }
 
     @Override
@@ -181,16 +191,25 @@ class AsyncCommandCursor<T> implements AsyncCursor<T> {
     }
 
     private void getMore(final ServerCursor cursor, final OperationContext operationContext, final SingleResultCallback<List<T>> callback) {
-        resourceManager.executeWithConnection(operationContext, (connection, wrappedCallback) ->
-                executeGetMoreCommand(assertNotNull(connection), cursor, operationContext, wrappedCallback), callback);
+        SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY, true);
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
+        AsyncCallbackSupplier<List<T>> retryingGetMore = decorateWithRetriesAsync(retryControl, operationContext, attemptCallback ->
+                resourceManager.executeWithConnection(operationContext, (connection, wrappedCallback) ->
+                        executeGetMoreCommand(assertNotNull(connection), cursor, operationContext, retryControl, wrappedCallback),
+                        attemptCallback));
+        retryingGetMore.get(callback);
     }
 
     private void executeGetMoreCommand(final AsyncConnection connection,
                                        final ServerCursor serverCursor,
                                        final OperationContext operationContext,
+                                       final RetryControl<SpecRetryPolicy> retryControl,
                                        final SingleResultCallback<List<T>> callback) {
+        BsonDocument command = getMoreCommandDocument(serverCursor.getId(), connection.getDescription(), namespace, batchSize, comment);
+        retryControl.getPolicy().onCommand(command::getFirstKey);
         connection.commandAsync(namespace.getDatabaseName(),
-                getMoreCommandDocument(serverCursor.getId(), connection.getDescription(), namespace, batchSize, comment),
+                command,
                 NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 CommandResultDocumentCodec.create(decoder, NEXT_BATCH),
                 operationContext,

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
@@ -390,9 +390,11 @@ final class AsyncOperationHelper {
                                                                     @Nullable final BsonValue comment,
                                                                     final AsyncConnectionSource source,
                                                                     final AsyncConnection connection,
-                                                                    final OperationContext operationContext) {
+                                                                    final OperationContext operationContext,
+                                                                    final boolean retryReads,
+                                                                    @Nullable final Integer maxAdaptiveRetriesSetting) {
         return new AsyncCommandBatchCursor<>(timeoutMode, 0, operationContext, new AsyncCommandCursor<>(
-                cursorDocument, batchSize, decoder, comment, source, connection
+                cursorDocument, batchSize, decoder, comment, source, connection, retryReads, maxAdaptiveRetriesSetting
         ));
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/ClientBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ClientBulkWriteOperation.java
@@ -80,6 +80,7 @@ import com.mongodb.internal.connection.DualMessageSequences;
 import com.mongodb.internal.connection.IdHoldingBsonWriter;
 import com.mongodb.internal.connection.MongoWriteConcernWithResponseException;
 import com.mongodb.internal.connection.OperationContext;
+import com.mongodb.internal.connection.OverloadStateSuspendedSessionContext;
 import com.mongodb.internal.session.BaseClientSessionImpl;
 import com.mongodb.internal.session.SessionContext;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
@@ -424,7 +425,9 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
         ClientBulkWriteCommandOkResponse response = new ClientBulkWriteCommandOkResponse(okResponseDocument);
         List<List<BsonDocument>> cursorExhaustBatches = retryControl.doWhileDisabled(() -> {
             onNotTryingToStartTransaction(operationContext.getSessionContext().getOverloadRetryPolicyState());
-            return exhaustBulkWriteCommandOkResponseCursor(connectionSource, operationContext, connection, response);
+            OperationContext getMoreOperationContext = operationContext.withSessionContext(
+                    new OverloadStateSuspendedSessionContext(operationContext.getSessionContext()));
+            return exhaustBulkWriteCommandOkResponseCursor(connectionSource, getMoreOperationContext, connection, response);
         });
         return createExhaustiveClientBulkWriteCommandOkResponse(
                 response,
@@ -462,7 +465,9 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
             beginAsync().<List<List<BsonDocument>>>thenSupply(exhaustCallback -> {
                 retryControl.doWhileDisabledAsync((actionCallback) -> {
                     onNotTryingToStartTransaction(operationContext.getSessionContext().getOverloadRetryPolicyState());
-                    exhaustBulkWriteCommandOkResponseCursorAsync(connectionSource, connection, response, operationContext, actionCallback);
+                    OperationContext getMoreOperationContext = operationContext.withSessionContext(
+                            new OverloadStateSuspendedSessionContext(operationContext.getSessionContext()));
+                    exhaustBulkWriteCommandOkResponseCursorAsync(connectionSource, connection, response, getMoreOperationContext, actionCallback);
                 }, exhaustCallback);
             }).<ExhaustiveClientBulkWriteCommandOkResponse>thenApply((cursorExhaustBatches, transformExhaustionResultCallback) -> {
                 transformExhaustionResultCallback.complete(createExhaustiveClientBulkWriteCommandOkResponse(

--- a/driver-core/src/main/com/mongodb/internal/operation/ClientBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ClientBulkWriteOperation.java
@@ -157,24 +157,29 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
     private final ConcreteClientBulkWriteOptions options;
     private final WriteConcern writeConcernSetting;
     private final boolean retryWritesSetting;
+    private final boolean retryReadsSetting;
     @Nullable
     private final Integer maxAdaptiveRetriesSetting;
     private final CodecRegistry codecRegistry;
 
     /**
      * @param retryWritesSetting See {@link MongoClientSettings#getRetryWrites()}.
+     * @param retryReadsSetting See {@link MongoClientSettings#getRetryReads()}. Governs overload retry of the
+     *                          results-cursor {@code getMore}, which is a read command at the wire level.
      */
     public ClientBulkWriteOperation(
             final List<? extends ClientNamespacedWriteModel> models,
             @Nullable final ClientBulkWriteOptions options,
             final WriteConcern writeConcernSetting,
             final boolean retryWritesSetting,
+            final boolean retryReadsSetting,
             @Nullable final Integer maxAdaptiveRetriesSetting,
             final CodecRegistry codecRegistry) {
         this.models = models;
         this.options = options == null ? EMPTY_OPTIONS : (ConcreteClientBulkWriteOptions) options;
         this.writeConcernSetting = writeConcernSetting;
         this.retryWritesSetting = retryWritesSetting;
+        this.retryReadsSetting = retryReadsSetting;
         this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
         this.codecRegistry = codecRegistry;
     }
@@ -509,7 +514,9 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
                 options.getComment().orElse(null),
                 connectionSource,
                 connection,
-                operationContext)) {
+                operationContext,
+                retryReadsSetting,
+                maxAdaptiveRetriesSetting)) {
 
            return cursor.exhaust();
         }
@@ -530,7 +537,9 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
                     options.getComment().orElse(null),
                     connectionSource,
                     connection,
-                    operationContext);
+                    operationContext,
+                    retryReadsSetting,
+                    maxAdaptiveRetriesSetting);
 
             beginAsync().<List<List<BsonDocument>>>thenSupply(exhaustCallback -> {
                 cursor.exhaust(exhaustCallback);

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandCursor.java
@@ -231,11 +231,11 @@ class CommandCursor<T> implements Cursor<T> {
 
     private void getMore(final OperationContext operationContext) {
         ServerCursor serverCursor = assertNotNull(resourceManager.getServerCursor());
-        resourceManager.executeWithConnection(connection -> {
-            SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
-                    .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY);
-            RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
-            Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
+        SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY);
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
+        Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
+            resourceManager.executeWithConnection(connection -> {
                 ServerCursor nextServerCursor;
                 BsonDocument command = getMoreCommandDocument(serverCursor.getId(), connection.getDescription(), namespace, batchSize,
                         comment);
@@ -254,10 +254,10 @@ class CommandCursor<T> implements Cursor<T> {
                     throw translateCommandException(e, serverCursor);
                 }
                 resourceManager.setServerCursor(nextServerCursor);
-                return null;
-            });
-            retryingCommandExecutor.get();
-        }, operationContext);
+            }, operationContext);
+            return null;
+        });
+        retryingCommandExecutor.get();
     }
 
     private CommandCursorResult<T> toCommandCursorResult(final ServerAddress serverAddress, final String fieldNameContainingBatch,

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandCursor.java
@@ -234,7 +234,7 @@ class CommandCursor<T> implements Cursor<T> {
         SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
                 .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY, true);
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
-        decorateWithRetries(retryControl, operationContext, () -> {
+        Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             resourceManager.executeWithConnection(connection -> {
                 ServerCursor nextServerCursor;
                 BsonDocument command = getMoreCommandDocument(serverCursor.getId(), connection.getDescription(), namespace, batchSize,
@@ -256,7 +256,8 @@ class CommandCursor<T> implements Cursor<T> {
                 resourceManager.setServerCursor(nextServerCursor);
             }, operationContext);
             return null;
-        }).get();
+        });
+        retryingCommandExecutor.get();
     }
 
     private CommandCursorResult<T> toCommandCursorResult(final ServerAddress serverAddress, final String fieldNameContainingBatch,

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandCursor.java
@@ -28,6 +28,7 @@ import com.mongodb.annotations.ThreadSafe;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerType;
 import com.mongodb.internal.VisibleForTesting;
+import com.mongodb.internal.async.function.RetryControl;
 import com.mongodb.internal.binding.ConnectionSource;
 import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.connection.OperationContext;
@@ -47,6 +48,8 @@ import java.util.function.Supplier;
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
+import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
+import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.FIRST_BATCH;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.MESSAGE_IF_CLOSED_AS_CURSOR;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.MESSAGE_IF_CLOSED_AS_ITERATOR;
@@ -65,6 +68,9 @@ class CommandCursor<T> implements Cursor<T> {
     private final int maxWireVersion;
     private final boolean firstBatchEmpty;
     private final ResourceManager resourceManager;
+    private final boolean retryReads;
+    @Nullable
+    private final Integer maxAdaptiveRetriesSetting;
 
     private int batchSize;
     private CommandCursorResult<T> commandCursorResult;
@@ -77,7 +83,9 @@ class CommandCursor<T> implements Cursor<T> {
             final Decoder<T> decoder,
             @Nullable final BsonValue comment,
             final ConnectionSource connectionSource,
-            final Connection connection) {
+            final Connection connection,
+            final boolean retryReads,
+            @Nullable final Integer maxAdaptiveRetriesSetting) {
         ConnectionDescription connectionDescription = connection.getDescription();
         this.commandCursorResult = toCommandCursorResult(connectionDescription.getServerAddress(), FIRST_BATCH, commandCursorDocument);
         this.namespace = commandCursorResult.getNamespace();
@@ -89,6 +97,8 @@ class CommandCursor<T> implements Cursor<T> {
 
         Connection connectionToPin = connectionSource.getServerDescription().getType() == ServerType.LOAD_BALANCER ? connection : null;
         resourceManager = new ResourceManager(namespace, connectionSource, connectionToPin, commandCursorResult.getServerCursor());
+        this.retryReads = retryReads;
+        this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
     }
 
     @Override
@@ -221,24 +231,32 @@ class CommandCursor<T> implements Cursor<T> {
 
     private void getMore(final OperationContext operationContext) {
         ServerCursor serverCursor = assertNotNull(resourceManager.getServerCursor());
-        resourceManager.executeWithConnection(connection -> {
-            ServerCursor nextServerCursor;
-            try {
-                this.commandCursorResult = toCommandCursorResult(connection.getDescription().getServerAddress(), NEXT_BATCH,
-                        assertNotNull(
-                                connection.command(namespace.getDatabaseName(),
-                                        getMoreCommandDocument(serverCursor.getId(), connection.getDescription(), namespace, batchSize,
-                                                comment),
-                                        NoOpFieldNameValidator.INSTANCE,
-                                        ReadPreference.primary(),
-                                        CommandResultDocumentCodec.create(decoder, NEXT_BATCH),
-                                        operationContext)));
-                nextServerCursor = commandCursorResult.getServerCursor();
-            } catch (MongoCommandException e) {
-                throw translateCommandException(e, serverCursor);
-            }
-            resourceManager.setServerCursor(nextServerCursor);
-        }, operationContext);
+        SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY, true);
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
+        decorateWithRetries(retryControl, operationContext, () -> {
+            resourceManager.executeWithConnection(connection -> {
+                ServerCursor nextServerCursor;
+                BsonDocument command = getMoreCommandDocument(serverCursor.getId(), connection.getDescription(), namespace, batchSize,
+                        comment);
+                retryControl.getPolicy().onCommand(command::getFirstKey);
+                try {
+                    this.commandCursorResult = toCommandCursorResult(connection.getDescription().getServerAddress(), NEXT_BATCH,
+                            assertNotNull(
+                                    connection.command(namespace.getDatabaseName(),
+                                            command,
+                                            NoOpFieldNameValidator.INSTANCE,
+                                            ReadPreference.primary(),
+                                            CommandResultDocumentCodec.create(decoder, NEXT_BATCH),
+                                            operationContext)));
+                    nextServerCursor = commandCursorResult.getServerCursor();
+                } catch (MongoCommandException e) {
+                    throw translateCommandException(e, serverCursor);
+                }
+                resourceManager.setServerCursor(nextServerCursor);
+            }, operationContext);
+            return null;
+        }).get();
     }
 
     private CommandCursorResult<T> toCommandCursorResult(final ServerAddress serverAddress, final String fieldNameContainingBatch,

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandCursor.java
@@ -231,11 +231,11 @@ class CommandCursor<T> implements Cursor<T> {
 
     private void getMore(final OperationContext operationContext) {
         ServerCursor serverCursor = assertNotNull(resourceManager.getServerCursor());
-        SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY);
-        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
-        Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
-            resourceManager.executeWithConnection(connection -> {
+        resourceManager.executeWithConnection(connection -> {
+            SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
+                    .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY);
+            RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
+            Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
                 ServerCursor nextServerCursor;
                 BsonDocument command = getMoreCommandDocument(serverCursor.getId(), connection.getDescription(), namespace, batchSize,
                         comment);
@@ -254,10 +254,10 @@ class CommandCursor<T> implements Cursor<T> {
                     throw translateCommandException(e, serverCursor);
                 }
                 resourceManager.setServerCursor(nextServerCursor);
-            }, operationContext);
-            return null;
-        });
-        retryingCommandExecutor.get();
+                return null;
+            });
+            retryingCommandExecutor.get();
+        }, operationContext);
     }
 
     private CommandCursorResult<T> toCommandCursorResult(final ServerAddress serverAddress, final String fieldNameContainingBatch,

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandCursor.java
@@ -232,7 +232,7 @@ class CommandCursor<T> implements Cursor<T> {
     private void getMore(final OperationContext operationContext) {
         ServerCursor serverCursor = assertNotNull(resourceManager.getServerCursor());
         SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY, true);
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY);
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             resourceManager.executeWithConnection(connection -> {

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandReadOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandReadOperation.java
@@ -78,6 +78,6 @@ public final class CommandReadOperation<T> extends AbstractCommandReadOperation<
     private SpecRetryPolicy.IndividualPolicies createRetryPolicy() {
         boolean retryPolicyEnabled = retryReads && retryWrites;
         return new SpecRetryPolicy.IndividualPolicies(retryPolicyEnabled)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY, false);
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandReadOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandReadOperation.java
@@ -78,6 +78,6 @@ public final class CommandReadOperation<T> extends AbstractCommandReadOperation<
     private SpecRetryPolicy.IndividualPolicies createRetryPolicy() {
         boolean retryPolicyEnabled = retryReads && retryWrites;
         return new SpecRetryPolicy.IndividualPolicies(retryPolicyEnabled)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY, false);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
@@ -476,7 +476,8 @@ public class FindOperation<T> implements ReadOperationExplainable<T> {
         return (result, source, connection, operationContext) ->
                 new CommandBatchCursor<>(getTimeoutMode(), getMaxTimeForCursor(operationContext), operationContext,
                         new CommandCursor<>(
-                                result, batchSize, decoder, comment, source, connection
+                                result, batchSize, decoder, comment, source, connection,
+                                retryReads, maxAdaptiveRetriesSetting
                 ));
     }
 
@@ -485,7 +486,8 @@ public class FindOperation<T> implements ReadOperationExplainable<T> {
                 new AsyncCommandBatchCursor<>(getTimeoutMode(), getMaxTimeForCursor(operationContext), operationContext,
                         new AsyncCommandCursor<>(
                                 result, batchSize, decoder,
-                                comment, source, connection
+                                comment, source, connection,
+                                retryReads, maxAdaptiveRetriesSetting
                         ));
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
@@ -227,12 +227,14 @@ public class ListCollectionsOperation<T> implements ReadOperationCursor<T> {
 
     private CommandReadTransformer<BsonDocument, BatchCursor<T>> transformer() {
         return (result, source, connection, operationContext) ->
-                cursorDocumentToBatchCursor(timeoutMode, result, batchSize, decoder, comment, source, connection, operationContext);
+                cursorDocumentToBatchCursor(timeoutMode, result, batchSize, decoder, comment, source, connection, operationContext,
+                        retryReads, maxAdaptiveRetriesSetting);
     }
 
     private CommandReadTransformerAsync<BsonDocument, AsyncBatchCursor<T>> asyncTransformer() {
         return (result, source, connection, operationContext) ->
-                cursorDocumentToAsyncBatchCursor(timeoutMode, result, batchSize, decoder, comment, source, connection, operationContext);
+                cursorDocumentToAsyncBatchCursor(timeoutMode, result, batchSize, decoder, comment, source, connection, operationContext,
+                        retryReads, maxAdaptiveRetriesSetting);
     }
 
 

--- a/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
@@ -194,12 +194,14 @@ public class ListIndexesOperation<T> implements ReadOperationCursor<T> {
 
     private CommandReadTransformer<BsonDocument, BatchCursor<T>> transformer() {
         return (result, source, connection, operationContext) ->
-                cursorDocumentToBatchCursor(timeoutMode, result, batchSize, decoder, comment, source, connection, operationContext);
+                cursorDocumentToBatchCursor(timeoutMode, result, batchSize, decoder, comment, source, connection, operationContext,
+                        retryReads, maxAdaptiveRetriesSetting);
     }
 
     private CommandReadTransformerAsync<BsonDocument, AsyncBatchCursor<T>> asyncTransformer() {
         return (result, source, connection, operationContext) ->
-                cursorDocumentToAsyncBatchCursor(timeoutMode, result, batchSize, decoder, comment, source, connection, operationContext);
+                cursorDocumentToAsyncBatchCursor(timeoutMode, result, batchSize, decoder, comment, source, connection, operationContext,
+                        retryReads, maxAdaptiveRetriesSetting);
     }
 
     private Codec<BsonDocument> createCommandDecoder() {

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -819,7 +819,8 @@ public final class Operations<T> {
     public WriteOperation<ClientBulkWriteResult> clientBulkWriteOperation(
             final List<? extends ClientNamespacedWriteModel> clientWriteModels,
             @Nullable final ClientBulkWriteOptions options) {
-        return new ClientBulkWriteOperation(clientWriteModels, options, writeConcern, retryWrites, maxAdaptiveRetriesSetting, codecRegistry);
+        return new ClientBulkWriteOperation(clientWriteModels, options, writeConcern, retryWrites, retryReads, maxAdaptiveRetriesSetting,
+                codecRegistry);
     }
 
     private Codec<T> getCodec() {

--- a/driver-core/src/main/com/mongodb/internal/operation/SpecRetryPolicy.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SpecRetryPolicy.java
@@ -385,7 +385,7 @@ final class SpecRetryPolicy implements RetryPolicy {
          * Use this overload when {@link #includeRead(OperationContext)} or {@link #includeWrite()} is also included;
          */
         IndividualPolicies includeOverload(@Nullable final Integer maxAdaptiveRetriesSetting) {
-            include(Descriptor.OVERLOAD, new State.Overload(effectiveRetrySetting, maxAdaptiveRetriesSetting, null));
+            include(Descriptor.OVERLOAD, new State.Overload(effectiveRetrySetting, maxAdaptiveRetriesSetting, null, false));
             return this;
         }
 
@@ -396,10 +396,22 @@ final class SpecRetryPolicy implements RetryPolicy {
          *
          * @param errorPropagation selects the error propagation shape applied by
          *                         {@link SpecRetryPolicy#decideProspectiveFailedResult}.
+         * @param sessionScopeUpdatesSuspended when {@code true}, this retry policy will not open, mutate, or close
+         *                                     the session's
+         *                                     {@link BaseClientSessionImpl.OverloadRetryPolicyState.CommandExecutionScoped command execution scope}.
+         *                                     Set for child retry controls executed inside another retry supplier's
+         *                                     execution (e.g. the cursor {@code getMore} retry in
+         *                                     {@link CommandCursor} / {@link AsyncCommandCursor} invoked while
+         *                                     iterating a bulk-write cursor inside
+         *                                     {@link com.mongodb.internal.async.function.RetryControl#doWhileDisabled(java.util.function.Supplier)}
+         *                                     where the parent {@link ClientBulkWriteOperation} attempt's scope is
+         *                                     still open).
          */
         IndividualPolicies includeOverload(@Nullable final Integer maxAdaptiveRetriesSetting,
-                                           final ErrorPropagation errorPropagation) {
-            include(Descriptor.OVERLOAD, new State.Overload(effectiveRetrySetting, maxAdaptiveRetriesSetting, errorPropagation));
+                                           final ErrorPropagation errorPropagation,
+                                           final boolean sessionScopeUpdatesSuspended) {
+            include(Descriptor.OVERLOAD, new State.Overload(
+                    effectiveRetrySetting, maxAdaptiveRetriesSetting, errorPropagation, sessionScopeUpdatesSuspended));
             return this;
         }
 
@@ -558,6 +570,17 @@ final class SpecRetryPolicy implements RetryPolicy {
                 private final Integer maxAdaptiveRetriesSetting;
                 @Nullable
                 private final ErrorPropagation errorPropagation;
+                /**
+                 * When {@code true}, this policy does not open, mutate, or close the session's
+                 * {@link BaseClientSessionImpl.OverloadRetryPolicyState.CommandExecutionScoped command execution scope}.
+                 * Set for child retry controls executed inside another retry supplier's execution — for example, the
+                 * cursor {@code getMore} retry loop in {@link CommandCursor} / {@link AsyncCommandCursor} invoked
+                 * while iterating a bulk-write cursor inside
+                 * {@link com.mongodb.internal.async.function.RetryControl#doWhileDisabled(java.util.function.Supplier)}
+                 * where the parent {@link ClientBulkWriteOperation} attempt still holds an open command execution
+                 * scope on the session.
+                 */
+                private final boolean sessionScopeUpdatesSuspended;
                 @Nullable
                 private BaseClientSessionImpl.OverloadRetryPolicyState sessionScopedState;
 
@@ -566,10 +589,12 @@ final class SpecRetryPolicy implements RetryPolicy {
                         @Nullable
                         final Integer maxAdaptiveRetriesSetting,
                         @Nullable
-                        final ErrorPropagation errorPropagation) {
+                        final ErrorPropagation errorPropagation,
+                        final boolean sessionScopeUpdatesSuspended) {
                     requirementsMet = effectiveRetrySetting;
                     this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
                     this.errorPropagation = errorPropagation;
+                    this.sessionScopeUpdatesSuspended = sessionScopeUpdatesSuspended;
                     sessionScopedState = null;
                 }
 
@@ -586,7 +611,7 @@ final class SpecRetryPolicy implements RetryPolicy {
 
                 void onAttemptStart(final RetryContext retryContext, final BaseClientSessionImpl.OverloadRetryPolicyState sessionScopedState) {
                     this.sessionScopedState = sessionScopedState;
-                    if (retryContext.isFirstAttempt()) {
+                    if (retryContext.isFirstAttempt() && !sessionScopeUpdatesSuspended) {
                         sessionScopedState.openCommandExecutionScope();
                     }
                 }
@@ -602,6 +627,9 @@ final class SpecRetryPolicy implements RetryPolicy {
                 }
 
                 private void onAnyAttemptFailure(final boolean retryableOverloadError) {
+                    if (sessionScopeUpdatesSuspended) {
+                        return;
+                    }
                     BaseClientSessionImpl.OverloadRetryPolicyState localSessionScopedState = assertNotNull(sessionScopedState);
                     assertNotNull(localSessionScopedState.getCommandExecutionScoped()).onAnyAttemptFailure(retryableOverloadError);
                     BaseClientSessionImpl.OverloadRetryPolicyState.CommitScoped commitScopedState = localSessionScopedState.getCommitScoped();
@@ -618,7 +646,9 @@ final class SpecRetryPolicy implements RetryPolicy {
                 }
 
                 void onLastAttemptCompletion() {
-                    assertNotNull(sessionScopedState).closeCommandExecutionScope();
+                    if (!sessionScopeUpdatesSuspended) {
+                        assertNotNull(sessionScopedState).closeCommandExecutionScope();
+                    }
                 }
 
                 @Override
@@ -690,7 +720,7 @@ final class SpecRetryPolicy implements RetryPolicy {
 
     /**
      * Selects the error propagation shape for overload-only policy
-     * compositions (see {@link IndividualPolicies#includeOverload(Integer, ErrorPropagation)}).
+     * compositions (see {@link IndividualPolicies#includeOverload(Integer, ErrorPropagation, boolean)}).
      */
     enum ErrorPropagation {
         AS_READ_POLICY,

--- a/driver-core/src/main/com/mongodb/internal/operation/SpecRetryPolicy.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SpecRetryPolicy.java
@@ -386,7 +386,7 @@ final class SpecRetryPolicy implements RetryPolicy {
          * Use this overload when {@link #includeRead(OperationContext)} or {@link #includeWrite()} is also included;
          */
         IndividualPolicies includeOverload(@Nullable final Integer maxAdaptiveRetriesSetting) {
-            include(Descriptor.OVERLOAD, new State.Overload(effectiveRetrySetting, maxAdaptiveRetriesSetting, null, false));
+            include(Descriptor.OVERLOAD, new State.Overload(effectiveRetrySetting, maxAdaptiveRetriesSetting, null));
             return this;
         }
 
@@ -400,28 +400,7 @@ final class SpecRetryPolicy implements RetryPolicy {
          */
         IndividualPolicies includeOverload(@Nullable final Integer maxAdaptiveRetriesSetting,
                                            final ErrorPropagation errorPropagation) {
-            return includeOverload(maxAdaptiveRetriesSetting, errorPropagation, false);
-        }
-
-        /**
-         * See {@link #includeOverload(Integer, ErrorPropagation)}.
-         *
-         * @param sessionScopeUpdatesSuspended when {@code true}, this policy will not open, mutate, or close the
-         *                                     session's
-         *                                     {@link BaseClientSessionImpl.OverloadRetryPolicyState.CommandExecutionScoped command execution scope}.
-         *                                     Set to {@code true} only for child retry controls executed inside
-         *                                     another retry supplier's execution - for example, the cursor
-         *                                     {@code getMore} retry in {@link CommandCursor} / {@link AsyncCommandCursor}
-         *                                     invoked while iterating a bulk-write cursor inside
-         *                                     {@link RetryControl#doWhileDisabled(Supplier)}
-         *                                     where the parent {@link ClientBulkWriteOperation} attempt's scope is
-         *                                     still open.
-         */
-        IndividualPolicies includeOverload(@Nullable final Integer maxAdaptiveRetriesSetting,
-                                           final ErrorPropagation errorPropagation,
-                                           final boolean sessionScopeUpdatesSuspended) {
-            include(Descriptor.OVERLOAD, new State.Overload(
-                    effectiveRetrySetting, maxAdaptiveRetriesSetting, errorPropagation, sessionScopeUpdatesSuspended));
+            include(Descriptor.OVERLOAD, new State.Overload(effectiveRetrySetting, maxAdaptiveRetriesSetting, errorPropagation));
             return this;
         }
 
@@ -580,17 +559,6 @@ final class SpecRetryPolicy implements RetryPolicy {
                 private final Integer maxAdaptiveRetriesSetting;
                 @Nullable
                 private final ErrorPropagation errorPropagation;
-                /**
-                 * When {@code true}, this policy does not open, mutate, or close the session's
-                 * {@link BaseClientSessionImpl.OverloadRetryPolicyState.CommandExecutionScoped command execution scope}.
-                 * Set for child retry controls executed inside another retry supplier's execution — for example, the
-                 * cursor {@code getMore} retry loop in {@link CommandCursor} / {@link AsyncCommandCursor} invoked
-                 * while iterating a bulk-write cursor inside
-                 * {@link com.mongodb.internal.async.function.RetryControl#doWhileDisabled(java.util.function.Supplier)}
-                 * where the parent {@link ClientBulkWriteOperation} attempt still holds an open command execution
-                 * scope on the session.
-                 */
-                private final boolean sessionScopeUpdatesSuspended;
                 @Nullable
                 private BaseClientSessionImpl.OverloadRetryPolicyState sessionScopedState;
 
@@ -599,12 +567,10 @@ final class SpecRetryPolicy implements RetryPolicy {
                         @Nullable
                         final Integer maxAdaptiveRetriesSetting,
                         @Nullable
-                        final ErrorPropagation errorPropagation,
-                        final boolean sessionScopeUpdatesSuspended) {
+                        final ErrorPropagation errorPropagation) {
                     requirementsMet = effectiveRetrySetting;
                     this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
                     this.errorPropagation = errorPropagation;
-                    this.sessionScopeUpdatesSuspended = sessionScopeUpdatesSuspended;
                     sessionScopedState = null;
                 }
 
@@ -621,7 +587,7 @@ final class SpecRetryPolicy implements RetryPolicy {
 
                 void onAttemptStart(final RetryContext retryContext, final BaseClientSessionImpl.OverloadRetryPolicyState sessionScopedState) {
                     this.sessionScopedState = sessionScopedState;
-                    if (retryContext.isFirstAttempt() && !sessionScopeUpdatesSuspended) {
+                    if (retryContext.isFirstAttempt()) {
                         sessionScopedState.openCommandExecutionScope();
                     }
                 }
@@ -637,9 +603,6 @@ final class SpecRetryPolicy implements RetryPolicy {
                 }
 
                 private void onAnyAttemptFailure(final boolean retryableOverloadError) {
-                    if (sessionScopeUpdatesSuspended) {
-                        return;
-                    }
                     BaseClientSessionImpl.OverloadRetryPolicyState localSessionScopedState = assertNotNull(sessionScopedState);
                     assertNotNull(localSessionScopedState.getCommandExecutionScoped()).onAnyAttemptFailure(retryableOverloadError);
                     BaseClientSessionImpl.OverloadRetryPolicyState.CommitScoped commitScopedState = localSessionScopedState.getCommitScoped();
@@ -656,9 +619,7 @@ final class SpecRetryPolicy implements RetryPolicy {
                 }
 
                 void onLastAttemptCompletion() {
-                    if (!sessionScopeUpdatesSuspended) {
-                        assertNotNull(sessionScopedState).closeCommandExecutionScope();
-                    }
+                    assertNotNull(sessionScopedState).closeCommandExecutionScope();
                 }
 
                 @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/SpecRetryPolicy.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SpecRetryPolicy.java
@@ -25,6 +25,7 @@ import com.mongodb.MongoSocketException;
 import com.mongodb.assertions.Assertions;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.internal.async.function.RetryContext;
+import com.mongodb.internal.async.function.RetryControl;
 import com.mongodb.internal.async.function.RetryPolicy;
 import com.mongodb.internal.async.function.RetryPolicy.Decision.RetryAttemptInfo;
 import com.mongodb.internal.connection.OperationContext;
@@ -396,16 +397,25 @@ final class SpecRetryPolicy implements RetryPolicy {
          *
          * @param errorPropagation selects the error propagation shape applied by
          *                         {@link SpecRetryPolicy#decideProspectiveFailedResult}.
-         * @param sessionScopeUpdatesSuspended when {@code true}, this retry policy will not open, mutate, or close
-         *                                     the session's
+         */
+        IndividualPolicies includeOverload(@Nullable final Integer maxAdaptiveRetriesSetting,
+                                           final ErrorPropagation errorPropagation) {
+            return includeOverload(maxAdaptiveRetriesSetting, errorPropagation, false);
+        }
+
+        /**
+         * See {@link #includeOverload(Integer, ErrorPropagation)}.
+         *
+         * @param sessionScopeUpdatesSuspended when {@code true}, this policy will not open, mutate, or close the
+         *                                     session's
          *                                     {@link BaseClientSessionImpl.OverloadRetryPolicyState.CommandExecutionScoped command execution scope}.
-         *                                     Set for child retry controls executed inside another retry supplier's
-         *                                     execution (e.g. the cursor {@code getMore} retry in
-         *                                     {@link CommandCursor} / {@link AsyncCommandCursor} invoked while
-         *                                     iterating a bulk-write cursor inside
-         *                                     {@link com.mongodb.internal.async.function.RetryControl#doWhileDisabled(java.util.function.Supplier)}
+         *                                     Set to {@code true} only for child retry controls executed inside
+         *                                     another retry supplier's execution - for example, the cursor
+         *                                     {@code getMore} retry in {@link CommandCursor} / {@link AsyncCommandCursor}
+         *                                     invoked while iterating a bulk-write cursor inside
+         *                                     {@link RetryControl#doWhileDisabled(Supplier)}
          *                                     where the parent {@link ClientBulkWriteOperation} attempt's scope is
-         *                                     still open).
+         *                                     still open.
          */
         IndividualPolicies includeOverload(@Nullable final Integer maxAdaptiveRetriesSetting,
                                            final ErrorPropagation errorPropagation,
@@ -720,7 +730,7 @@ final class SpecRetryPolicy implements RetryPolicy {
 
     /**
      * Selects the error propagation shape for overload-only policy
-     * compositions (see {@link IndividualPolicies#includeOverload(Integer, ErrorPropagation, boolean)}).
+     * compositions (see {@link IndividualPolicies#includeOverload(Integer, ErrorPropagation)}).
      */
     enum ErrorPropagation {
         AS_READ_POLICY,

--- a/driver-core/src/main/com/mongodb/internal/operation/SpecRetryPolicy.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SpecRetryPolicy.java
@@ -25,7 +25,6 @@ import com.mongodb.MongoSocketException;
 import com.mongodb.assertions.Assertions;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.internal.async.function.RetryContext;
-import com.mongodb.internal.async.function.RetryControl;
 import com.mongodb.internal.async.function.RetryPolicy;
 import com.mongodb.internal.async.function.RetryPolicy.Decision.RetryAttemptInfo;
 import com.mongodb.internal.connection.OperationContext;

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
@@ -386,9 +386,11 @@ final class SyncOperationHelper {
             final BsonValue comment,
             final ConnectionSource source,
             final Connection connection,
-            final OperationContext operationContext) {
+            final OperationContext operationContext,
+            final boolean retryReads,
+            @Nullable final Integer maxAdaptiveRetriesSetting) {
         return new CommandBatchCursor<>(timeoutMode, 0, operationContext, new CommandCursor<>(
-                cursorDocument, batchSize, decoder, comment, source, connection
+                cursorDocument, batchSize, decoder, comment, source, connection, retryReads, maxAdaptiveRetriesSetting
         ));
 
     }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AsyncCommandBatchCursorFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AsyncCommandBatchCursorFunctionalTest.java
@@ -112,7 +112,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         // given
         BsonDocument commandResult = executeFindCommand(0, 3); // Fetch in batches of size 3
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
+                new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
        // when
         FutureResultCallback<List<List<Document>>> futureCallback = new FutureResultCallback<>();
@@ -134,7 +134,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         // given
         BsonDocument commandResult = executeFindCommand(0, 3);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
+                new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         cursor.close();
 
@@ -157,7 +157,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(0, 3); // No documents to fetch
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
+                new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         // when
         FutureResultCallback<List<List<Document>>> futureCallback = new FutureResultCallback<>();
@@ -174,7 +174,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     void theServerCursorShouldNotBeNull() {
         BsonDocument commandResult = executeFindCommand(2);
         AsyncCommandCursor<Document> coreCursor =
-                new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection);
+                new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 coreCursor);
 
@@ -186,7 +186,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     void shouldGetExceptionsForOperationsOnTheCursorAfterClosing() {
         BsonDocument commandResult = executeFindCommand(5);
         AsyncCommandCursor<Document> coreCursor =
-                new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection);
+                new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 coreCursor);
 
@@ -203,7 +203,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     void shouldThrowAnExceptionWhenGoingOffTheEnd() {
         BsonDocument commandResult = executeFindCommand(2, 1);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
+                new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         cursorNext();
         cursorNext();
@@ -217,7 +217,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     void testNormalExhaustion() {
         BsonDocument commandResult = executeFindCommand();
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
+                new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertEquals(10, cursorFlatten().size());
     }
@@ -228,7 +228,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     void testLimitExhaustion(final int limit, final int batchSize, final int expectedTotal) {
         BsonDocument commandResult = executeFindCommand(limit, batchSize);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new AsyncCommandCursor<>(commandResult, batchSize, DOCUMENT_DECODER, null, connectionSource, connection));
+                new AsyncCommandCursor<>(commandResult, batchSize, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
 
         assertEquals(expectedTotal, cursorFlatten().size());
@@ -247,7 +247,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, awaitData);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, ClusterFixture.createOperationContext(),
-                new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
+                new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertFalse(cursor.isClosed());
         assertEquals(1, cursorNext().get(0).get("_id"));
@@ -270,7 +270,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
+                new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         CountDownLatch latch = new CountDownLatch(1);
         AtomicInteger seen = new AtomicInteger();
@@ -303,7 +303,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 10);
         AsyncCommandCursor<Document> coreCursor =
-                new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection);
+                new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 coreCursor);
 
@@ -318,7 +318,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 3);
         AsyncCommandCursor<Document> coreCursor =
-                new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection);
+                new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection, false, null);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 coreCursor);
 
@@ -340,7 +340,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(5, 10);
         AsyncCommandCursor<Document> coreCursor =
-                new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection);
+                new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 coreCursor);
 
@@ -355,7 +355,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 3);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
+                new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertNotNull(cursorNext());
         assertNotNull(cursorNext());
@@ -368,7 +368,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     void testLimitWithGetMore() {
         BsonDocument commandResult = executeFindCommand(5, 2);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
+                new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertNotNull(cursorNext());
         assertNotNull(cursorNext());
@@ -391,7 +391,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(300, 0);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
+                new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertEquals(300, cursorFlatten().size());
     }
@@ -401,7 +401,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     void shouldRespectBatchSize() {
         BsonDocument commandResult = executeFindCommand(2);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
+                new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertEquals(2, cursor.getBatchSize());
         assertEquals(2, cursorNext().size());
@@ -418,7 +418,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     void shouldThrowCursorNotFoundException() throws Throwable {
         BsonDocument commandResult = executeFindCommand(2);
         AsyncCommandCursor<Document> coreCursor =
-                new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection);
+                new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection, false, null);
         cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 coreCursor);
 

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AsyncCommandCursorTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AsyncCommandCursorTest.java
@@ -235,6 +235,8 @@ class AsyncCommandCursorTest {
                 DOCUMENT_CODEC,
                 null,
                 connectionSource,
-                mockConnection);
+                mockConnection,
+                false,
+                null);
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CommandBatchCursorFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CommandBatchCursorFunctionalTest.java
@@ -111,7 +111,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         // given
         BsonDocument commandResult = executeFindCommand(0, 3); // Fetch in batches of size 3
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         // when
         List<List<Document>> result = cursor.exhaust();
@@ -129,7 +129,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         // given
         BsonDocument commandResult = executeFindCommand(0, 3);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
         cursor.close();
 
         // when & then
@@ -145,7 +145,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(0, 3); // No documents to fetch
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         // when
         List<List<Document>> result = cursor.exhaust();
@@ -159,7 +159,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void theServerCursorShouldNotBeNull() {
         BsonDocument commandResult = executeFindCommand(2);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertNotNull(cursor.getServerCursor());
     }
@@ -169,7 +169,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void theServerAddressShouldNotNull() {
         BsonDocument commandResult = executeFindCommand();
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertNotNull(cursor.getServerAddress());
     }
@@ -179,7 +179,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldGetExceptionsForOperationsOnTheCursorAfterClosing() {
         BsonDocument commandResult = executeFindCommand();
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         cursor.close();
 
@@ -194,7 +194,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldThrowAnExceptionWhenGoingOffTheEnd() {
         BsonDocument commandResult = executeFindCommand(1);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         cursor.next();
         cursor.next();
@@ -206,7 +206,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void testCursorRemove() {
         BsonDocument commandResult = executeFindCommand();
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertThrows(UnsupportedOperationException.class, () -> cursor.remove());
     }
@@ -216,7 +216,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void testNormalExhaustion() {
         BsonDocument commandResult = executeFindCommand();
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertEquals(10, cursorFlatten().size());
     }
@@ -227,7 +227,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void testLimitExhaustion(final int limit, final int batchSize, final int expectedTotal) {
         BsonDocument commandResult = executeFindCommand(limit, batchSize);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertEquals(expectedTotal, cursorFlatten().size());
 
@@ -246,7 +246,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, awaitData);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertTrue(cursor.hasNext());
         assertEquals(1, cursor.next().get(0).get("_id"));
@@ -269,7 +269,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         List<Document> nextBatch = cursor.tryNext();
         assertNotNull(nextBatch);
@@ -295,7 +295,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertTrue(cursor.hasNext());
         assertEquals(1, cursor.next().get(0).get("_id"));
@@ -322,7 +322,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         List<Document> nextBatch = cursor.tryNext();
         assertNotNull(nextBatch);
@@ -346,7 +346,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         CountDownLatch latch = new CountDownLatch(1);
         AtomicInteger seen = new AtomicInteger();
@@ -379,7 +379,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 10);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertNotNull(cursor.next());
         assertFalse(cursor.hasNext());
@@ -392,7 +392,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 3);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         ServerCursor serverCursor = cursor.getServerCursor();
         assertNotNull(serverCursor);
@@ -411,7 +411,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 10);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertNull(cursor.getServerCursor());
         assertDoesNotThrow(() -> checkReferenceCountReachesTarget(connectionSource, 1));
@@ -424,7 +424,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 3);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertNotNull(cursor.next());
         assertNotNull(cursor.next());
@@ -437,7 +437,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void testLimitWithGetMore() {
         BsonDocument commandResult = executeFindCommand(5, 2);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertNotNull(cursor.next());
         assertNotNull(cursor.next());
@@ -458,7 +458,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(300, 0);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertEquals(300, cursorFlatten().size());
     }
@@ -468,7 +468,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldRespectBatchSize() {
         BsonDocument commandResult = executeFindCommand(2);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertEquals(2, cursor.getBatchSize());
         assertEquals(2, cursor.next().size());
@@ -485,7 +485,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldThrowCursorNotFoundException() {
         BsonDocument commandResult = executeFindCommand(2);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         ServerCursor serverCursor = cursor.getServerCursor();
         assertNotNull(serverCursor);
@@ -508,7 +508,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldReportAvailableDocuments() {
         BsonDocument commandResult = executeFindCommand(3);
         cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
-                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
+                new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection, false, null));
 
         assertEquals(3, cursor.available());
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageTest.java
@@ -145,6 +145,7 @@ class CommandMessageTest {
                         clientBulkWriteOptions(),
                         WriteConcern.MAJORITY,
                         retryWrites,
+                        false,
                         null,
                         getDefaultCodecRegistry()
                 ).new BatchEncoder(),

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncCommandBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncCommandBatchCursorSpecification.groovy
@@ -72,7 +72,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def reply =  getMoreResponse([], 0)
 
         when:
-        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, batchSize, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, batchSize, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new AsyncCommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, operationContext, commandCoreCursor)
         then:
         1 * timeoutContext.withMaxTimeOverride(*_)
@@ -111,7 +111,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def connection = referenceCountedAsyncConnection(serverVersion)
         def connectionSource = getAsyncConnectionSource(connection)
         def operationContext = getOperationContext()
-        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new AsyncCommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
 
         when:
@@ -142,7 +142,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
 
         when:
         def firstBatch = createCommandResult(FIRST_BATCH, 0)
-        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new AsyncCommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
 
         then:
@@ -173,7 +173,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
 
         when:
         def firstBatch = createCommandResult([], CURSOR_ID)
-        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new AsyncCommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
         def batch = nextBatch(cursor)
 
@@ -223,7 +223,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def firstBatch = createCommandResult()
 
         when:
-        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new AsyncCommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
         def batch = nextBatch(cursor)
 
@@ -278,7 +278,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
 
         when:
         def commandCoreCursor = new AsyncCommandCursor<>(createCommandResult(FIRST_BATCH, 42), 0,
-                CODEC, null, connectionSource, initialConnection)
+                CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new AsyncCommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
         def batch = nextBatch(cursor)
 
@@ -314,7 +314,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def firstBatch = createCommandResult()
 
         when:
-        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new AsyncCommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
         def batch = nextBatch(cursor)
 
@@ -354,7 +354,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def initialConnection = referenceCountedAsyncConnection()
         def connectionSource = getAsyncConnectionSourceWithResult(ServerType.STANDALONE) { [null, MONGO_EXCEPTION] }
         def firstBatch = createCommandResult()
-        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new AsyncCommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
 
         when:
@@ -374,7 +374,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
 
         when:
         def firstBatch = createCommandResult()
-        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new AsyncCommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
 
         then:
@@ -401,7 +401,7 @@ class AsyncCommandBatchCursorSpecification extends Specification {
 
         when:
         def firstBatch = createCommandResult()
-        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new AsyncCommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncCommandBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncCommandBatchCursorSpecification.groovy
@@ -72,7 +72,14 @@ class AsyncCommandBatchCursorSpecification extends Specification {
         def reply =  getMoreResponse([], 0)
 
         when:
-        def commandCoreCursor = new AsyncCommandCursor<>(firstBatch, batchSize, CODEC, null, connectionSource, initialConnection, false, null)
+        def commandCoreCursor = new AsyncCommandCursor<>(
+                firstBatch, batchSize,
+                CODEC,
+                null,
+                connectionSource,
+                initialConnection,
+                false,
+                null)
         def cursor = new AsyncCommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, operationContext, commandCoreCursor)
         then:
         1 * timeoutContext.withMaxTimeOverride(*_)

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/ClientBulkWriteOperationTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/ClientBulkWriteOperationTest.java
@@ -122,6 +122,7 @@ class ClientBulkWriteOperationTest {
                 options,
                 WriteConcern.ACKNOWLEDGED,
                 false,
+                false,
                 null,
                 getDefaultCodecRegistry());
         //when
@@ -174,6 +175,7 @@ class ClientBulkWriteOperationTest {
                 clientNamespacedReplaceOneModels,
                 options,
                 WriteConcern.ACKNOWLEDGED,
+                false,
                 false,
                 null,
                 getDefaultCodecRegistry());

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/CommandBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/CommandBatchCursorSpecification.groovy
@@ -73,7 +73,7 @@ class CommandBatchCursorSpecification extends Specification {
         def reply =  getMoreResponse([], 0)
 
         when:
-        def commandCoreCursor = new CommandCursor<>(firstBatch, batchSize, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new CommandCursor<>(firstBatch, batchSize, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new CommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, operationContext, commandCoreCursor)
 
         then:
@@ -109,7 +109,7 @@ class CommandBatchCursorSpecification extends Specification {
         def serverVersion = new ServerVersion([3, 6, 0])
         def connection = referenceCountedConnection(serverVersion)
         def connectionSource = getConnectionSource(connection)
-        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new CommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
 
         when:
@@ -137,7 +137,7 @@ class CommandBatchCursorSpecification extends Specification {
 
         when:
         def firstBatch = createCommandResult(FIRST_BATCH, 0)
-        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new CommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
 
         then:
@@ -161,7 +161,7 @@ class CommandBatchCursorSpecification extends Specification {
 
         when:
         def firstBatch = createCommandResult([], CURSOR_ID)
-        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new CommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
         def batch = cursor.next()
 
@@ -215,7 +215,7 @@ class CommandBatchCursorSpecification extends Specification {
         def firstBatch = createCommandResult()
 
         when:
-        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new CommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
         List<Document> batch = cursor.next()
 
@@ -268,7 +268,7 @@ class CommandBatchCursorSpecification extends Specification {
 
         when:
         def commandCoreCursor = new CommandCursor<>(createCommandResult(FIRST_BATCH, 42), 0, CODEC,
-                null, connectionSource, initialConnection)
+                null, connectionSource, initialConnection, false, null)
         def cursor = new CommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
         def batch = cursor.next()
 
@@ -304,7 +304,7 @@ class CommandBatchCursorSpecification extends Specification {
         def firstBatch = createCommandResult()
 
         when:
-        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new CommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
         def batch = cursor.next()
 
@@ -343,7 +343,7 @@ class CommandBatchCursorSpecification extends Specification {
         def initialConnection = referenceCountedConnection()
         def connectionSource = getConnectionSourceWithResult(ServerType.STANDALONE) { throw MONGO_EXCEPTION }
         def firstBatch = createCommandResult()
-        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new CommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
 
         when:
@@ -364,7 +364,7 @@ class CommandBatchCursorSpecification extends Specification {
 
         when:
         def firstBatch = createCommandResult()
-        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new CommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
 
         then:
@@ -391,7 +391,7 @@ class CommandBatchCursorSpecification extends Specification {
 
         when:
         def firstBatch = createCommandResult()
-        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new CommandCursor<>(firstBatch, 0, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new CommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 0, operationContext, commandCoreCursor)
         then:
         connectionSource.getCount() == 1
@@ -450,7 +450,7 @@ class CommandBatchCursorSpecification extends Specification {
         connectionSource.retain() >> connectionSource
 
         def initialResults = createCommandResult([])
-        def commandCoreCursor = new CommandCursor<>(initialResults, 2, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new CommandCursor<>(initialResults, 2, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new CommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 100, operationContext, commandCoreCursor)
 
         when:
@@ -476,7 +476,7 @@ class CommandBatchCursorSpecification extends Specification {
         connectionSource.retain() >> connectionSource
 
         def initialResults = createCommandResult([])
-        def commandCoreCursor = new CommandCursor<>(initialResults, 2, CODEC, null, connectionSource, initialConnection)
+        def commandCoreCursor = new CommandCursor<>(initialResults, 2, CODEC, null, connectionSource, initialConnection, false, null)
         def cursor = new CommandBatchCursor<Document>(TimeoutMode.CURSOR_LIFETIME, 100, operationContext, commandCoreCursor)
 
         when:

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/CommandCursorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/CommandCursorTest.java
@@ -172,6 +172,8 @@ class CommandCursorTest {
                 DOCUMENT_CODEC,
                 null,
                 connectionSource,
-                mockConnection);
+                mockConnection,
+                false,
+                null);
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/BackpressureProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/BackpressureProseTest.java
@@ -17,8 +17,35 @@
 package com.mongodb.reactivestreams.client;
 
 import com.mongodb.MongoClientSettings;
-import com.mongodb.client.MongoClient;
+import com.mongodb.MongoServerException;
+import com.mongodb.client.FailPoint;
+import com.mongodb.event.CommandEvent;
+import com.mongodb.event.CommandFailedEvent;
+import com.mongodb.event.CommandStartedEvent;
+import com.mongodb.event.CommandSucceededEvent;
+import com.mongodb.internal.connection.TestCommandListener;
 import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static com.mongodb.MongoException.RETRYABLE_ERROR_LABEL;
+import static com.mongodb.MongoException.SYSTEM_OVERLOADED_ERROR_LABEL;
+import static com.mongodb.client.Fixture.getDefaultDatabaseName;
+import static com.mongodb.client.Fixture.getMongoClientSettings;
+import static com.mongodb.client.Fixture.getPrimary;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * <a href="https://github.com/mongodb/specifications/blob/master/source/client-backpressure/tests/README.md#prose-tests">
@@ -26,7 +53,80 @@ import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
  */
 final class BackpressureProseTest extends com.mongodb.client.BackpressureProseTest {
     @Override
-    protected MongoClient createClient(final MongoClientSettings mongoClientSettings) {
+    protected com.mongodb.client.MongoClient createClient(final MongoClientSettings mongoClientSettings) {
         return new SyncMongoClient(mongoClientSettings);
+    }
+
+    /**
+     * Reactive counterpart of {@code getMore-retried-backpressure.yml} scenario
+     * "getMores are retried maxAttempts=2 times". Skipped by the unified runner
+     * because {@code BatchCursorFlux} signals {@code sink.error(e)} without awaiting
+     * the {@code killCursors} reply, so the runner may snapshot events before
+     * {@code killCursors} succeeds. Here we sleep after the terminal error to let
+     * the async close land, then assert the full command sequence.
+     */
+    @Test
+    void getMoreExhaustsOverloadRetriesAndCursorIsKilled() throws TimeoutException, InterruptedException {
+        assumeTrue(serverVersionAtLeast(8, 0));
+
+        //given
+        BsonDocument overloadOnGetMoreAlways = BsonDocument.parse(
+                "{"
+                + "    configureFailPoint: 'failCommand',"
+                + "    mode: 'alwaysOn',"
+                + "    data: {"
+                + "        failCommands: ['getMore'],"
+                + "        errorCode: 2,"
+                + "        errorLabels: ['" + RETRYABLE_ERROR_LABEL + "', '" + SYSTEM_OVERLOADED_ERROR_LABEL + "']"
+                + "    }"
+                + "}");
+        TestCommandListener commandListener = new TestCommandListener();
+        try (MongoClient client = MongoClients.create(MongoClientSettings.builder(getMongoClientSettings())
+                .retryReads(true)
+                .addCommandListener(commandListener)
+                .build())) {
+
+            MongoCollection<Document> coll = client.getDatabase(getDefaultDatabaseName()).getCollection("test");
+            Mono.from(coll.insertMany(asList(new Document(), new Document(), new Document()))).block(TIMEOUT_DURATION);
+            commandListener.reset();
+
+            //when
+            try (FailPoint ignored = FailPoint.enable(overloadOnGetMoreAlways, getPrimary())) {
+                assertThrows(MongoServerException.class,
+                        () -> Flux.from(coll.find().batchSize(2)).blockLast(TIMEOUT_DURATION));
+            }
+            commandListener.waitForEvents(CommandSucceededEvent.class,
+                    e -> "killCursors".equals(e.getCommandName()), 1);
+
+            //then
+            List<CommandEvent> events = commandListener.getEvents();
+            assertEquals(10, events.size());
+            assertStarted(events.get(0), "find");
+            assertSucceeded(events.get(1), "find");
+            assertStarted(events.get(2), "getMore");
+            assertFailed(events.get(3), "getMore");
+            assertStarted(events.get(4), "getMore");
+            assertFailed(events.get(5), "getMore");
+            assertStarted(events.get(6), "getMore");
+            assertFailed(events.get(7), "getMore");
+            assertStarted(events.get(8), "killCursors");
+            assertSucceeded(events.get(9), "killCursors");
+        }
+    }
+
+    private static void assertStarted(final CommandEvent event, final String commandName) {
+        assertInstanceOf(CommandStartedEvent.class, event);
+        assertEquals(commandName, event.getCommandName());
+    }
+
+    private static void assertSucceeded(final CommandEvent event, final String commandName) {
+        assertInstanceOf(CommandSucceededEvent.class, event);
+        assertEquals(commandName, event.getCommandName());
+    }
+
+
+    private static void assertFailed(final CommandEvent event, final String commandName) {
+        assertInstanceOf(CommandFailedEvent.class, event);
+        assertEquals(commandName, event.getCommandName());
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/BackpressureProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/BackpressureProseTest.java
@@ -62,8 +62,8 @@ final class BackpressureProseTest extends com.mongodb.client.BackpressureProseTe
      * "getMores are retried maxAttempts=2 times". Skipped by the unified runner
      * because {@code BatchCursorFlux} signals {@code sink.error(e)} without awaiting
      * the {@code killCursors} reply, so the runner may snapshot events before
-     * {@code killCursors} succeeds. Here we sleep after the terminal error to let
-     * the async close land, then assert the full command sequence.
+     * {@code killCursors} succeeds. Here we wait for that command to complete, then
+     * assert the full command sequence.
      */
     @Test
     void getMoreExhaustsOverloadRetriesAndCursorIsKilled() throws TimeoutException, InterruptedException {

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -461,7 +461,7 @@ public class BackpressureProseTest {
         // batches (server sizes firstBatch by response size, not count), guaranteeing a getMore.
         int maxBsonObjectSize = client.getDatabase("admin")
                 .runCommand(new Document("hello", 1)).getInteger("maxBsonObjectSize");
-        MongoNamespace namespace = new MongoNamespace(getDefaultDatabaseName(), "clientBulkWriteGetMoreCoverage");
+        MongoNamespace namespace = new MongoNamespace(getDefaultDatabaseName(), BackpressureProseTest.class.getName());
         List<? extends ClientNamespacedWriteModel> models = asList(
                 ClientNamespacedWriteModel.updateOne(
                         namespace,

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -36,12 +36,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import static com.mongodb.client.model.bulk.ClientBulkWriteOptions.clientBulkWriteOptions;
 import static com.mongodb.client.model.bulk.ClientUpdateOneOptions.clientUpdateOneOptions;
+import static java.lang.String.join;
+import static java.util.Arrays.asList;
+import static java.util.Collections.nCopies;
 
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.MongoException.RETRYABLE_ERROR_LABEL;
@@ -379,7 +381,7 @@ public class BackpressureProseTest {
                 .build())) {
             try (FailPoint ignored = FailPoint.enable(overloadOnGetMoreOnce, getPrimary())) {
                 ClientBulkWriteResult result = executeClientBulkWrite(client);
-                assertEquals(102, result.getUpsertedCount());
+                assertEquals(2, result.getUpsertedCount());
             }
             assertEquals(2, commandListener.getCommandStartedEvents("getMore").size(),
                     "Expected exactly two getMore attempts (overload retry + terminal success)");
@@ -483,17 +485,22 @@ public class BackpressureProseTest {
     }
 
     private static ClientBulkWriteResult executeClientBulkWrite(final MongoClient client) {
-        // 102 upserts exceed the server's default firstBatch size (101) for the bulkWrite response cursor,
-        // guaranteeing at least one getMore.
+        // Two upserts whose result docs each approach maxBsonObjectSize force the response cursor to span two
+        // batches, guaranteeing a getMore.
+        int maxBsonObjectSize = client.getDatabase("admin")
+                .runCommand(new Document("hello", 1)).getInteger("maxBsonObjectSize");
         MongoNamespace namespace = new MongoNamespace(getDefaultDatabaseName(), BackpressureProseTest.class.getName());
-        List<ClientNamespacedWriteModel> models = new ArrayList<>(102);
-        for (int i = 0; i < 102; i++) {
-            models.add(ClientNamespacedWriteModel.updateOne(
-                    namespace,
-                    Filters.eq("_id", i),
-                    Updates.set("x", 1),
-                    clientUpdateOneOptions().upsert(true)));
-        }
+        List<? extends ClientNamespacedWriteModel> models = asList(
+                ClientNamespacedWriteModel.updateOne(
+                        namespace,
+                        Filters.eq(join("", nCopies(maxBsonObjectSize / 2, "a"))),
+                        Updates.set("x", 1),
+                        clientUpdateOneOptions().upsert(true)),
+                ClientNamespacedWriteModel.updateOne(
+                        namespace,
+                        Filters.eq(join("", nCopies(maxBsonObjectSize / 2, "b"))),
+                        Updates.set("x", 1),
+                        clientUpdateOneOptions().upsert(true)));
         return client.bulkWrite(models, clientBulkWriteOptions().verboseResults(true));
     }
 

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -18,7 +18,12 @@ package com.mongodb.client;
 
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
+import com.mongodb.MongoNamespace;
 import com.mongodb.MongoServerException;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Updates;
+import com.mongodb.client.model.bulk.ClientBulkWriteResult;
+import com.mongodb.client.model.bulk.ClientNamespacedWriteModel;
 import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.internal.connection.TestCommandListener;
 import com.mongodb.internal.event.ConfigureFailPointCommandListener;
@@ -27,10 +32,18 @@ import com.mongodb.internal.time.StartTime;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
+
+import static com.mongodb.client.model.bulk.ClientBulkWriteOptions.clientBulkWriteOptions;
+import static com.mongodb.client.model.bulk.ClientUpdateOneOptions.clientUpdateOneOptions;
+import static java.lang.String.join;
+import static java.util.Arrays.asList;
+import static java.util.Collections.nCopies;
 
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.MongoException.RETRYABLE_ERROR_LABEL;
@@ -54,6 +67,11 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public class BackpressureProseTest {
     protected MongoClient createClient(final MongoClientSettings mongoClientSettings) {
         return MongoClients.create(mongoClientSettings);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Fixture.getDefaultDatabase().drop();
     }
 
     /**
@@ -337,6 +355,125 @@ public class BackpressureProseTest {
             assertEquals(1, commandListener.getCommandStartedEvents("ping").size(),
                     "Expected exactly one ping attempt (runCommand overload-only policy does not retry retryable-read codes)");
         }
+    }
+
+    /**
+     * Coverage test (not part of the spec prose suite).
+     */
+    @Test
+    void clientBulkWriteGetMoreRetriesOverloadWhenRetryReadsEnabled() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(8, 0));
+        BsonDocument overloadOnGetMoreOnce = BsonDocument.parse(
+                "{\n"
+                + "    configureFailPoint: 'failCommand',\n"
+                + "    mode: {times: 1},\n"
+                + "    data: {\n"
+                + "        failCommands: ['getMore'],\n"
+                + "        errorCode: 462,\n"
+                + "        errorLabels: ['" + SYSTEM_OVERLOADED_ERROR_LABEL + "', '" + RETRYABLE_ERROR_LABEL + "']\n"
+                + "    }\n"
+                + "}\n");
+        TestCommandListener commandListener = new TestCommandListener();
+        try (MongoClient client = createClient(MongoClientSettings.builder(getMongoClientSettings())
+                .retryWrites(false)
+                .retryReads(true)
+                .addCommandListener(commandListener)
+                .build())) {
+            commandListener.reset();
+            try (FailPoint ignored = FailPoint.enable(overloadOnGetMoreOnce, getPrimary())) {
+                ClientBulkWriteResult result = executeClientBulkWrite(client);
+                assertEquals(2, result.getUpsertedCount());
+            }
+            assertEquals(2, commandListener.getCommandStartedEvents("getMore").size(),
+                    "Expected exactly two getMore attempts (overload retry + terminal success)");
+        }
+    }
+
+    /**
+     * Coverage test (not part of the spec prose suite).
+     */
+    @Test
+    void clientBulkWriteGetMoreDoesNotRetryNonOverloadError() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(8, 0));
+        BsonDocument retryableReadCodeOnGetMoreOnce = BsonDocument.parse(
+                "{\n"
+                + "    configureFailPoint: 'failCommand',\n"
+                + "    mode: {times: 1},\n"
+                + "    data: {\n"
+                + "        failCommands: ['getMore'],\n"
+                + "        errorCode: 11602\n"
+                + "    }\n"
+                + "}\n");
+        TestCommandListener commandListener = new TestCommandListener();
+        try (MongoClient client = createClient(MongoClientSettings.builder(getMongoClientSettings())
+                .retryWrites(false)
+                .retryReads(true)
+                .addCommandListener(commandListener)
+                .build())) {
+            commandListener.reset();
+            try (FailPoint ignored = FailPoint.enable(retryableReadCodeOnGetMoreOnce, getPrimary())) {
+                MongoServerException exception = assertThrows(MongoServerException.class,
+                        () -> executeClientBulkWrite(client));
+                assertEquals(11602, ((MongoCommandException) exception).getErrorCode(),
+                        "Expected propagated non-overload error, got: " + exception);
+            }
+            assertEquals(1, commandListener.getCommandStartedEvents("getMore").size(),
+                    "Expected exactly one getMore attempt (non-overload error is not retried)");
+        }
+    }
+
+    /**
+     * Coverage test (not part of the spec prose suite).
+     */
+    @Test
+    void clientBulkWriteGetMoreDoesNotRetryOverloadWhenRetryReadsDisabled() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(8, 0));
+        BsonDocument overloadOnGetMoreOnce = BsonDocument.parse(
+                "{\n"
+                + "    configureFailPoint: 'failCommand',\n"
+                + "    mode: {times: 1},\n"
+                + "    data: {\n"
+                + "        failCommands: ['getMore'],\n"
+                + "        errorCode: 462,\n"
+                + "        errorLabels: ['" + SYSTEM_OVERLOADED_ERROR_LABEL + "', '" + RETRYABLE_ERROR_LABEL + "']\n"
+                + "    }\n"
+                + "}\n");
+        TestCommandListener commandListener = new TestCommandListener();
+        try (MongoClient client = createClient(MongoClientSettings.builder(getMongoClientSettings())
+                .retryWrites(false)
+                .retryReads(false)
+                .addCommandListener(commandListener)
+                .build())) {
+            commandListener.reset();
+            try (FailPoint ignored = FailPoint.enable(overloadOnGetMoreOnce, getPrimary())) {
+                MongoServerException exception = assertThrows(MongoServerException.class,
+                        () -> executeClientBulkWrite(client));
+                assertTrue(exception.hasErrorLabel(SYSTEM_OVERLOADED_ERROR_LABEL),
+                        "Expected propagated overload error, got: " + exception);
+            }
+            assertEquals(1, commandListener.getCommandStartedEvents("getMore").size(),
+                    "Expected exactly one getMore attempt (retryReads=false disables overload retry for getMore)");
+        }
+    }
+
+    private static ClientBulkWriteResult executeClientBulkWrite(final MongoClient client) {
+        // Two upserts whose result docs each approach maxBsonObjectSize force the response cursor to span two
+        // batches (server sizes firstBatch by response size, not count), guaranteeing a getMore.
+        int maxBsonObjectSize = client.getDatabase("admin")
+                .runCommand(new Document("hello", 1)).getInteger("maxBsonObjectSize");
+        MongoNamespace namespace = new MongoNamespace(getDefaultDatabaseName(), "clientBulkWriteGetMoreCoverage");
+        List<? extends ClientNamespacedWriteModel> models = asList(
+                ClientNamespacedWriteModel.updateOne(
+                        namespace,
+                        Filters.eq(join("", nCopies(maxBsonObjectSize / 2, "a"))),
+                        Updates.set("x", 1),
+                        clientUpdateOneOptions().upsert(true)),
+                ClientNamespacedWriteModel.updateOne(
+                        namespace,
+                        Filters.eq(join("", nCopies(maxBsonObjectSize / 2, "b"))),
+                        Updates.set("x", 1),
+                        clientUpdateOneOptions().upsert(true)));
+        return client.bulkWrite(models, clientBulkWriteOptions().verboseResults(true));
     }
 
     private static MongoCollection<Document> dropAndGetCollection(final String name, final MongoClient client) {

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -379,13 +379,43 @@ public class BackpressureProseTest {
                 .retryReads(true)
                 .addCommandListener(commandListener)
                 .build())) {
-            commandListener.reset();
             try (FailPoint ignored = FailPoint.enable(overloadOnGetMoreOnce, getPrimary())) {
                 ClientBulkWriteResult result = executeClientBulkWrite(client);
                 assertEquals(2, result.getUpsertedCount());
             }
             assertEquals(2, commandListener.getCommandStartedEvents("getMore").size(),
                     "Expected exactly two getMore attempts (overload retry + terminal success)");
+        }
+    }
+
+    /**
+     * Coverage test (not part of the spec prose suite).
+     */
+    @Test
+    void clientBulkWriteGetMoreExhaustsOverloadRetriesAndThrows() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(8, 0));
+        BsonDocument overloadOnGetMoreAlways = BsonDocument.parse(
+                "{"
+                + "    configureFailPoint: 'failCommand',"
+                + "    mode: {times: " + (DEFAULT_MAX_ADAPTIVE_RETRIES + 1) + "},"
+                + "    data: {"
+                + "        failCommands: ['getMore'],"
+                + "        errorCode: 462,"
+                + "        errorLabels: ['" + SYSTEM_OVERLOADED_ERROR_LABEL + "', '" + RETRYABLE_ERROR_LABEL + "']"
+                + "    }"
+                + "}");
+        TestCommandListener commandListener = new TestCommandListener();
+        try (MongoClient client = createClient(MongoClientSettings.builder(getMongoClientSettings())
+                .retryWrites(false)
+                .retryReads(true)
+                .addCommandListener(commandListener)
+                .build())) {
+            try (FailPoint ignored = FailPoint.enable(overloadOnGetMoreAlways, getPrimary())) {
+                MongoServerException exception = assertThrows(MongoServerException.class, () -> executeClientBulkWrite(client));
+                assertTrue(exception.hasErrorLabel(SYSTEM_OVERLOADED_ERROR_LABEL));
+            }
+            assertEquals(DEFAULT_MAX_ADAPTIVE_RETRIES + 1, commandListener.getCommandStartedEvents("getMore").size(),
+                    "Expected all overload retry attempts to be exhausted (initial + maxAdaptiveRetries)");
         }
     }
 
@@ -410,7 +440,6 @@ public class BackpressureProseTest {
                 .retryReads(true)
                 .addCommandListener(commandListener)
                 .build())) {
-            commandListener.reset();
             try (FailPoint ignored = FailPoint.enable(retryableReadCodeOnGetMoreOnce, getPrimary())) {
                 MongoServerException exception = assertThrows(MongoServerException.class,
                         () -> executeClientBulkWrite(client));
@@ -444,7 +473,6 @@ public class BackpressureProseTest {
                 .retryReads(false)
                 .addCommandListener(commandListener)
                 .build())) {
-            commandListener.reset();
             try (FailPoint ignored = FailPoint.enable(overloadOnGetMoreOnce, getPrimary())) {
                 MongoServerException exception = assertThrows(MongoServerException.class,
                         () -> executeClientBulkWrite(client));

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -36,14 +36,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import static com.mongodb.client.model.bulk.ClientBulkWriteOptions.clientBulkWriteOptions;
 import static com.mongodb.client.model.bulk.ClientUpdateOneOptions.clientUpdateOneOptions;
-import static java.lang.String.join;
-import static java.util.Arrays.asList;
-import static java.util.Collections.nCopies;
 
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.MongoException.RETRYABLE_ERROR_LABEL;
@@ -485,22 +483,17 @@ public class BackpressureProseTest {
     }
 
     private static ClientBulkWriteResult executeClientBulkWrite(final MongoClient client) {
-        // Two upserts whose result docs each approach maxBsonObjectSize force the response cursor to span two
-        // batches (server sizes firstBatch by response size, not count), guaranteeing a getMore.
-        int maxBsonObjectSize = client.getDatabase("admin")
-                .runCommand(new Document("hello", 1)).getInteger("maxBsonObjectSize");
+        // 102 upserts exceed the server's default firstBatch size (101) for the bulkWrite response cursor,
+        // guaranteeing at least one getMore.
         MongoNamespace namespace = new MongoNamespace(getDefaultDatabaseName(), BackpressureProseTest.class.getName());
-        List<? extends ClientNamespacedWriteModel> models = asList(
-                ClientNamespacedWriteModel.updateOne(
-                        namespace,
-                        Filters.eq(join("", nCopies(maxBsonObjectSize / 2, "a"))),
-                        Updates.set("x", 1),
-                        clientUpdateOneOptions().upsert(true)),
-                ClientNamespacedWriteModel.updateOne(
-                        namespace,
-                        Filters.eq(join("", nCopies(maxBsonObjectSize / 2, "b"))),
-                        Updates.set("x", 1),
-                        clientUpdateOneOptions().upsert(true)));
+        List<ClientNamespacedWriteModel> models = new ArrayList<>(102);
+        for (int i = 0; i < 102; i++) {
+            models.add(ClientNamespacedWriteModel.updateOne(
+                    namespace,
+                    Filters.eq("_id", i),
+                    Updates.set("x", 1),
+                    clientUpdateOneOptions().upsert(true)));
+        }
         return client.bulkWrite(models, clientBulkWriteOptions().verboseResults(true));
     }
 

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -379,7 +379,7 @@ public class BackpressureProseTest {
                 .build())) {
             try (FailPoint ignored = FailPoint.enable(overloadOnGetMoreOnce, getPrimary())) {
                 ClientBulkWriteResult result = executeClientBulkWrite(client);
-                assertEquals(2, result.getUpsertedCount());
+                assertEquals(102, result.getUpsertedCount());
             }
             assertEquals(2, commandListener.getCommandStartedEvents("getMore").size(),
                     "Expected exactly two getMore attempts (overload retry + terminal success)");

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -614,6 +614,12 @@ public final class UnifiedTestModifications {
         def.skipJira("https://jira.mongodb.org/browse/JAVA-5956 TODO-JAVA-5956")
                 .test("client-backpressure", "tests that operations retry at most maxAttempts=2 times", "collection.aggregate write retries at most maxAttempts=2 times");
 
+        // BatchCursorFlux fires closeCursor() then sink.error(e) without awaiting the killCursors reply,
+        // so under reactive the test framework snapshots command events before killCursors succeeded lands.
+        // Equivalent coverage is provided by the reactive BackpressureProseTest.
+        def.skipNoncompliantReactive("Reactive cursor auto-close on error does not await killCursors reply")
+                .test("client-backpressure", "getMore-retried-backpressure", "getMores are retried maxAttempts=2 times");
+
         // valid-pass
 
         def.skipDeprecated("MongoDB releases prior to 4.4 incorrectly add "

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -613,8 +613,6 @@ public final class UnifiedTestModifications {
                 .test("client-backpressure", "tests that operations retry at most maxAttempts=2 times", "collection.dropIndexes retries at most maxAttempts=2 times");
         def.skipJira("https://jira.mongodb.org/browse/JAVA-5956 TODO-JAVA-5956")
                 .test("client-backpressure", "tests that operations retry at most maxAttempts=2 times", "collection.aggregate write retries at most maxAttempts=2 times");
-        def.skipJira("https://jira.mongodb.org/browse/JAVA-5956 TODO-JAVA-5956")
-                .file("client-backpressure", "getMore-retried-backpressure");
 
         // valid-pass
 


### PR DESCRIPTION
- Wraps CommandCursor / AsyncCommandCursor getMore in the SpecRetryPolicy overload-retry loop, gated by retryReads and propagated as a read command, so any read cursor (find, aggregate, listCollections, listIndexes, changeStream) and the bulk-write result cursor participates in the overload-retry loop when iterating.
- Threads retryReads / maxAdaptiveRetries through to cursor construction sites, including ClientBulkWriteOperation whose result-cursor getMore is a read at the wire level despite the parent being a write.
- Extends the overload sub-policy with sessionScopeUpdatesSuspended so a nested retry loop (cursor getMore invoked inside another retry supplier such as the bulk-write cursor exhaust under RetryControl.doWhileDisabled) does not open, mutate, or close the parent's still-open command execution scope on the session.
- Removes the JAVA-5956 skip for the getMore-retried-backpressure unified test and adds coverage prose tests for the bulk-write cursor's getMore under overload retry, non-overload propagation, and retryReads=false.

JAVA-6296