### PR TITLE
Adds overload retry for not read/write retryable commands

### DIFF
--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -289,6 +289,16 @@
 
     <!-- Void method returning null but @NotNull API -->
     <Match>
+        <Class name="com.mongodb.internal.operation.CreateCollectionOperation"/>
+        <Method name="execute"/>
+        <Bug pattern="NP_NONNULL_RETURN_VIOLATION"/>
+    </Match>
+    <Match>
+        <Class name="com.mongodb.internal.operation.DropCollectionOperation"/>
+        <Method name="execute"/>
+        <Bug pattern="NP_NONNULL_RETURN_VIOLATION"/>
+    </Match>
+    <Match>
         <Class name="com.mongodb.internal.operation.DropIndexOperation"/>
         <Method name="execute"/>
         <Bug pattern="NP_NONNULL_RETURN_VIOLATION"/>

--- a/driver-core/src/main/com/mongodb/internal/operation/AbstractWriteSearchIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AbstractWriteSearchIndexOperation.java
@@ -20,15 +20,22 @@ package com.mongodb.internal.operation;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
+import com.mongodb.internal.async.function.RetryControl;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
 import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 
+import java.util.function.Supplier;
+
+import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWithRetriesAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncSourceAndConnection;
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
+import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
 import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErrorTransformer;
@@ -40,39 +47,70 @@ import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErr
  */
 abstract class AbstractWriteSearchIndexOperation implements WriteOperation<Void> {
     private final MongoNamespace namespace;
+    private final boolean retryWrites;
+    @Nullable
+    private final Integer maxAdaptiveRetriesSetting;
 
     AbstractWriteSearchIndexOperation(final MongoNamespace namespace) {
+        this(namespace, false, null);
+    }
+
+    /**
+     * @param retryWrites Whether overload retries are enabled for this operation.
+     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
+     */
+    AbstractWriteSearchIndexOperation(final MongoNamespace namespace, final boolean retryWrites,
+            @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.namespace = namespace;
+        this.retryWrites = retryWrites;
+        this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
     }
 
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
-        return withConnection(binding, operationContext, (connection, operationContextWithMinRtt) -> {
-            try {
-                executeCommand(binding, operationContextWithMinRtt, namespace.getDatabaseName(), buildCommand(),
-                        connection,
-                        writeConcernErrorTransformer(operationContextWithMinRtt.getTimeoutContext()));
-            } catch (MongoCommandException mongoCommandException) {
-                swallowOrThrow(mongoCommandException);
-            }
-            return null;
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
+            retryControl.getPolicy().onCommand(this::getCommandName);
+            return withConnection(binding, operationContext, (connection, operationContextWithMinRtt) -> {
+                try {
+                    executeCommand(binding, operationContextWithMinRtt, namespace.getDatabaseName(), buildCommand(),
+                            connection,
+                            writeConcernErrorTransformer(operationContextWithMinRtt.getTimeoutContext()));
+                } catch (MongoCommandException mongoCommandException) {
+                    swallowOrThrow(mongoCommandException);
+                }
+                return null;
+            });
         });
+        return retryingCommandExecutor.get();
     }
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
-        withAsyncSourceAndConnection(binding::getWriteConnectionSource, false, operationContext, callback,
-                (connectionSource, connection, operationContextWithMinRtt, cb) ->
-                        executeCommandAsync(binding, operationContextWithMinRtt,  namespace.getDatabaseName(), buildCommand(), connection,
-                                writeConcernErrorTransformerAsync(operationContextWithMinRtt.getTimeoutContext()), (result, commandExecutionError) -> {
-                                    try {
-                                        swallowOrThrow(commandExecutionError);
-                                        cb.onResult(result, null);
-                                    } catch (Throwable mongoCommandException) {
-                                        cb.onResult(null, mongoCommandException);
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback -> {
+            retryControl.getPolicy().onCommand(this::getCommandName);
+            withAsyncSourceAndConnection(binding::getWriteConnectionSource, false, operationContext, supplierCallback,
+                    (connectionSource, connection, operationContextWithMinRtt, cb) ->
+                            executeCommandAsync(binding, operationContextWithMinRtt, namespace.getDatabaseName(), buildCommand(),
+                                    connection, writeConcernErrorTransformerAsync(operationContextWithMinRtt.getTimeoutContext()),
+                                    (result, commandExecutionError) -> {
+                                        try {
+                                            swallowOrThrow(commandExecutionError);
+                                            cb.onResult(result, null);
+                                        } catch (Throwable mongoCommandException) {
+                                            cb.onResult(null, mongoCommandException);
+                                        }
                                     }
-                                }
-                        ));
+                            ));
+        });
+        retryingCommandExecutor.get(callback);
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/operation/AbstractWriteSearchIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AbstractWriteSearchIndexOperation.java
@@ -55,10 +55,6 @@ abstract class AbstractWriteSearchIndexOperation implements WriteOperation<Void>
         this(namespace, false, null);
     }
 
-    /**
-     * @param retryWrites Whether overload retries are enabled for this operation.
-     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
-     */
     AbstractWriteSearchIndexOperation(final MongoNamespace namespace, final boolean retryWrites,
             @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.namespace = namespace;

--- a/driver-core/src/main/com/mongodb/internal/operation/AbstractWriteSearchIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AbstractWriteSearchIndexOperation.java
@@ -69,8 +69,7 @@ abstract class AbstractWriteSearchIndexOperation implements WriteOperation<Void>
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -91,8 +90,7 @@ abstract class AbstractWriteSearchIndexOperation implements WriteOperation<Void>
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 operationContext);
         AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -138,5 +136,10 @@ abstract class AbstractWriteSearchIndexOperation implements WriteOperation<Void>
     @Override
     public MongoNamespace getNamespace() {
         return namespace;
+    }
+
+    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
+        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/AbstractWriteSearchIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AbstractWriteSearchIndexOperation.java
@@ -35,6 +35,7 @@ import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommand
 import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncSourceAndConnection;
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
 import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
+import static com.mongodb.internal.operation.SpecRetryPolicy.IndividualPolicies.overloadForWrite;
 import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
@@ -65,7 +66,7 @@ abstract class AbstractWriteSearchIndexOperation implements WriteOperation<Void>
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                createSpecRetryPolicy(),
+                overloadForWrite(retryWrites, maxAdaptiveRetriesSetting),
                 operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -86,7 +87,7 @@ abstract class AbstractWriteSearchIndexOperation implements WriteOperation<Void>
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                createSpecRetryPolicy(),
+                overloadForWrite(retryWrites, maxAdaptiveRetriesSetting),
                 operationContext);
         AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -134,8 +135,4 @@ abstract class AbstractWriteSearchIndexOperation implements WriteOperation<Void>
         return namespace;
     }
 
-    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
-        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
-    }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateToCollectionOperation.java
@@ -193,8 +193,7 @@ public class AggregateToCollectionOperation implements ReadOperationSimple<Void>
                 getCommandCreator(),
                 new BsonDocumentCodec(),
                 transformer(),
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY));
+                createSpecRetryPolicy());
     }
 
     @Override
@@ -209,8 +208,7 @@ public class AggregateToCollectionOperation implements ReadOperationSimple<Void>
                 getCommandCreator(),
                 new BsonDocumentCodec(),
                 asyncTransformer(),
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 callback);
     }
 
@@ -265,5 +263,10 @@ public class AggregateToCollectionOperation implements ReadOperationSimple<Void>
                     connection.getDescription().getMaxWireVersion(), operationContext.getTimeoutContext());
             return null;
         };
+    }
+
+    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
+        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateToCollectionOperation.java
@@ -43,6 +43,7 @@ import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.operation.AsyncOperationHelper.CommandReadTransformerAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeRetryableReadAsync;
 import static com.mongodb.internal.operation.ServerVersionHelper.FIVE_DOT_ZERO_WIRE_VERSION;
+import static com.mongodb.internal.operation.SpecRetryPolicy.IndividualPolicies.overloadForWrite;
 import static com.mongodb.internal.operation.SyncOperationHelper.CommandReadTransformer;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeRetryableRead;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
@@ -189,7 +190,7 @@ public class AggregateToCollectionOperation implements ReadOperationSimple<Void>
                 getCommandCreator(),
                 new BsonDocumentCodec(),
                 transformer(),
-                createSpecRetryPolicy());
+                overloadForWrite(retryWrites, maxAdaptiveRetriesSetting));
     }
 
     @Override
@@ -204,7 +205,7 @@ public class AggregateToCollectionOperation implements ReadOperationSimple<Void>
                 getCommandCreator(),
                 new BsonDocumentCodec(),
                 asyncTransformer(),
-                createSpecRetryPolicy(),
+                overloadForWrite(retryWrites, maxAdaptiveRetriesSetting),
                 callback);
     }
 
@@ -261,8 +262,4 @@ public class AggregateToCollectionOperation implements ReadOperationSimple<Void>
         };
     }
 
-    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
-        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
-    }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateToCollectionOperation.java
@@ -64,6 +64,9 @@ public class AggregateToCollectionOperation implements ReadOperationSimple<Void>
     private final WriteConcern writeConcern;
     private final ReadConcern readConcern;
     private final AggregationLevel aggregationLevel;
+    private final boolean retryWrites;
+    @Nullable
+    private final Integer maxAdaptiveRetriesSetting;
 
     private Boolean allowDiskUse;
     private Boolean bypassDocumentValidation;
@@ -79,11 +82,23 @@ public class AggregateToCollectionOperation implements ReadOperationSimple<Void>
 
     public AggregateToCollectionOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline,
             @Nullable final ReadConcern readConcern, @Nullable final WriteConcern writeConcern, final AggregationLevel aggregationLevel) {
+        this(namespace, pipeline, readConcern, writeConcern, aggregationLevel, false, null);
+    }
+
+    /**
+     * @param retryWrites Whether overload retries are enabled for this operation.
+     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
+     */
+    public AggregateToCollectionOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline,
+            @Nullable final ReadConcern readConcern, @Nullable final WriteConcern writeConcern, final AggregationLevel aggregationLevel,
+            final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.namespace = notNull("namespace", namespace);
         this.pipeline = notNull("pipeline", pipeline);
         this.writeConcern = writeConcern;
         this.readConcern = readConcern;
         this.aggregationLevel = notNull("aggregationLevel", aggregationLevel);
+        this.retryWrites = retryWrites;
+        this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
 
         isTrueArgument("pipeline is not empty", !pipeline.isEmpty());
     }
@@ -178,8 +193,8 @@ public class AggregateToCollectionOperation implements ReadOperationSimple<Void>
                 getCommandCreator(),
                 new BsonDocumentCodec(),
                 transformer(),
-                false,
-                null);
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY));
     }
 
     @Override
@@ -194,8 +209,8 @@ public class AggregateToCollectionOperation implements ReadOperationSimple<Void>
                 getCommandCreator(),
                 new BsonDocumentCodec(),
                 asyncTransformer(),
-                false,
-                null,
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
                 callback);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateToCollectionOperation.java
@@ -85,10 +85,6 @@ public class AggregateToCollectionOperation implements ReadOperationSimple<Void>
         this(namespace, pipeline, readConcern, writeConcern, aggregationLevel, false, null);
     }
 
-    /**
-     * @param retryWrites Whether overload retries are enabled for this operation.
-     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
-     */
     public AggregateToCollectionOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline,
             @Nullable final ReadConcern readConcern, @Nullable final WriteConcern writeConcern, final AggregationLevel aggregationLevel,
             final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandCursor.java
@@ -54,6 +54,7 @@ import static com.mongodb.internal.async.AsyncRunnable.beginAsync;
 import static com.mongodb.internal.async.SingleResultCallback.THEN_DO_NOTHING;
 import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWithRetriesAsync;
 import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
+import static com.mongodb.internal.operation.SpecRetryPolicy.IndividualPolicies.overloadForRead;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.FIRST_BATCH;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.MESSAGE_IF_CLOSED_AS_CURSOR;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.NEXT_BATCH;
@@ -191,9 +192,8 @@ class AsyncCommandCursor<T> implements AsyncCursor<T> {
     }
 
     private void getMore(final ServerCursor cursor, final OperationContext operationContext, final SingleResultCallback<List<T>> callback) {
-        SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY);
-        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                overloadForRead(retryReads, maxAdaptiveRetriesSetting), operationContext);
         AsyncCallbackSupplier<List<T>> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, attemptCallback ->
                 resourceManager.executeWithConnection(operationContext, (connection, wrappedCallback) ->
                         executeGetMoreCommand(assertNotNull(connection), cursor, operationContext, retryControl, wrappedCallback),

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
@@ -27,7 +27,6 @@ import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.MutableValue;
 import com.mongodb.internal.async.SingleResultCallback;
-import com.mongodb.internal.async.function.AsyncCallbackBiFunction;
 import com.mongodb.internal.async.function.AsyncCallbackFunction;
 import com.mongodb.internal.async.function.AsyncCallbackSupplier;
 import com.mongodb.internal.async.function.AsyncCallbackTriFunction;
@@ -91,31 +90,6 @@ final class AsyncOperationHelper {
                                               final AsyncCallableWithSource callable) {
         binding.getReadConnectionSource(operationContext,
                 errorHandlingCallback(new AsyncCallableWithSourceCallback(callable), OperationHelper.LOGGER));
-    }
-
-    /**
-     * The asynchronous counterpart of {@code SyncOperationHelper.withWriteConnectionSource}.
-     *
-     * @see #withAsyncSuppliedResource(AsyncCallbackFunction, boolean, OperationContext, SingleResultCallback, AsyncCallbackFunction)
-     */
-    static <R> void withAsyncWriteConnectionSource(
-            final AsyncWriteBinding binding,
-            final OperationContext operationContext,
-            final SingleResultCallback<R> callback,
-            final AsyncCallbackBiFunction<AsyncConnectionSource, OperationContext, R> asyncFunction) {
-        SingleResultCallback<R> errorHandlingCallback = errorHandlingCallback(callback, OperationHelper.LOGGER);
-
-        OperationContext serverSelectionOperationContext =
-                operationContext.withOverride(TimeoutContext::withComputedServerSelectionTimeout);
-        withAsyncSuppliedResource(
-                binding::getWriteConnectionSource,
-                false,
-                serverSelectionOperationContext,
-                errorHandlingCallback,
-                (source, sourceReleasingCallback) -> asyncFunction.apply(
-                        source,
-                        operationContext.withMinRoundTripTime(source.getServerDescription()),
-                        sourceReleasingCallback));
     }
 
     static void withAsyncConnection(final AsyncWriteBinding binding,

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
@@ -27,6 +27,7 @@ import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.MutableValue;
 import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.async.function.AsyncCallbackBiFunction;
 import com.mongodb.internal.async.function.AsyncCallbackFunction;
 import com.mongodb.internal.async.function.AsyncCallbackSupplier;
 import com.mongodb.internal.async.function.AsyncCallbackTriFunction;
@@ -92,6 +93,31 @@ final class AsyncOperationHelper {
                 errorHandlingCallback(new AsyncCallableWithSourceCallback(callable), OperationHelper.LOGGER));
     }
 
+    /**
+     * The asynchronous counterpart of {@code SyncOperationHelper.withWriteConnectionSource}.
+     *
+     * @see #withAsyncSuppliedResource(AsyncCallbackFunction, boolean, OperationContext, SingleResultCallback, AsyncCallbackFunction)
+     */
+    static <R> void withAsyncWriteConnectionSource(
+            final AsyncWriteBinding binding,
+            final OperationContext operationContext,
+            final SingleResultCallback<R> callback,
+            final AsyncCallbackBiFunction<AsyncConnectionSource, OperationContext, R> asyncFunction) {
+        SingleResultCallback<R> errorHandlingCallback = errorHandlingCallback(callback, OperationHelper.LOGGER);
+
+        OperationContext serverSelectionOperationContext =
+                operationContext.withOverride(TimeoutContext::withComputedServerSelectionTimeout);
+        withAsyncSuppliedResource(
+                binding::getWriteConnectionSource,
+                false,
+                serverSelectionOperationContext,
+                errorHandlingCallback,
+                (source, sourceReleasingCallback) -> asyncFunction.apply(
+                        source,
+                        operationContext.withMinRoundTripTime(source.getServerDescription()),
+                        sourceReleasingCallback));
+    }
+
     static void withAsyncConnection(final AsyncWriteBinding binding,
                                     final OperationContext originalOperationContext,
                                     final AsyncCallableWithConnection callable) {
@@ -101,6 +127,25 @@ final class AsyncOperationHelper {
                 errorHandlingCallback(
                         new AsyncCallableWithConnectionCallback(callable, serverSelectionOperationContext, originalOperationContext),
                         OperationHelper.LOGGER));
+    }
+
+    /**
+     * The asynchronous counterpart of {@code SyncOperationHelper.withConnection(ConnectionSource, OperationContext, CallableWithConnection)}.
+     *
+     * @see #withAsyncSuppliedResource(AsyncCallbackFunction, boolean, OperationContext, SingleResultCallback, AsyncCallbackFunction)
+     */
+    static <R> void withAsyncConnection(
+            final AsyncConnectionSource source,
+            final OperationContext operationContext,
+            final SingleResultCallback<R> callback,
+            final AsyncCallbackBiFunction<AsyncConnection, OperationContext, R> asyncFunction) {
+        withAsyncSuppliedResource(
+                source::getConnection,
+                false,
+                operationContext,
+                callback,
+                (connection, connectionReleasingCallback) ->
+                        asyncFunction.apply(connection, operationContext, connectionReleasingCallback));
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
@@ -130,25 +130,6 @@ final class AsyncOperationHelper {
     }
 
     /**
-     * The asynchronous counterpart of {@code SyncOperationHelper.withConnection(ConnectionSource, OperationContext, CallableWithConnection)}.
-     *
-     * @see #withAsyncSuppliedResource(AsyncCallbackFunction, boolean, OperationContext, SingleResultCallback, AsyncCallbackFunction)
-     */
-    static <R> void withAsyncConnection(
-            final AsyncConnectionSource source,
-            final OperationContext operationContext,
-            final SingleResultCallback<R> callback,
-            final AsyncCallbackBiFunction<AsyncConnection, OperationContext, R> asyncFunction) {
-        withAsyncSuppliedResource(
-                source::getConnection,
-                false,
-                operationContext,
-                callback,
-                (connection, connectionReleasingCallback) ->
-                        asyncFunction.apply(connection, operationContext, connectionReleasingCallback));
-    }
-
-    /**
      * @see #withAsyncSuppliedResource(AsyncCallbackFunction, boolean, OperationContext, SingleResultCallback, AsyncCallbackFunction)
      */
     static <R> void withAsyncSourceAndConnection(

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandCursor.java
@@ -49,6 +49,7 @@ import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
 import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
+import static com.mongodb.internal.operation.SpecRetryPolicy.IndividualPolicies.overloadForRead;
 import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.FIRST_BATCH;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.MESSAGE_IF_CLOSED_AS_CURSOR;
@@ -231,9 +232,8 @@ class CommandCursor<T> implements Cursor<T> {
 
     private void getMore(final OperationContext operationContext) {
         ServerCursor serverCursor = assertNotNull(resourceManager.getServerCursor());
-        SpecRetryPolicy.IndividualPolicies policies = new SpecRetryPolicy.IndividualPolicies(retryReads)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_READ_POLICY);
-        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(policies, operationContext);
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                overloadForRead(retryReads, maxAdaptiveRetriesSetting), operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             resourceManager.executeWithConnection(connection -> {
                 ServerCursor nextServerCursor;

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandReadOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandReadOperation.java
@@ -25,6 +25,7 @@ import org.bson.BsonDocument;
 import org.bson.codecs.Decoder;
 
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeRetryableReadAsync;
+import static com.mongodb.internal.operation.SpecRetryPolicy.IndividualPolicies.overloadForWrite;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeRetryableRead;
 
 /**
@@ -76,8 +77,6 @@ public final class CommandReadOperation<T> extends AbstractCommandReadOperation<
     }
 
     private SpecRetryPolicy.IndividualPolicies createRetryPolicy() {
-        boolean retryPolicyEnabled = retryReads && retryWrites;
-        return new SpecRetryPolicy.IndividualPolicies(retryPolicyEnabled)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
+        return overloadForWrite(retryReads && retryWrites, maxAdaptiveRetriesSetting);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
@@ -30,9 +30,9 @@ import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.function.AsyncCallbackSupplier;
 import com.mongodb.internal.async.function.RetryControl;
+import com.mongodb.internal.binding.AsyncConnectionSource;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
-import com.mongodb.internal.connection.AsyncConnection;
 import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
@@ -48,21 +48,20 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.notNull;
-import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWithRetriesAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync;
-import static com.mongodb.internal.operation.AsyncOperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncConnection;
+import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncWriteConnectionSource;
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
 import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.DocumentHelper.putIfFalse;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotZero;
-import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsLessThanVersionSevenDotZero;
 import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
+import static com.mongodb.internal.operation.SyncOperationHelper.withWriteConnectionSource;
 import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErrorTransformer;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static java.util.Arrays.asList;
@@ -264,45 +263,35 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
 
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
-        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
-                operationContext);
-        Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
-            retryControl.getPolicy().onCommand(this::getCommandName);
-            return withConnection(binding, operationContext, (connection, operationContextWithMinRtt) -> {
-                checkEncryptedFieldsSupported(connection.getDescription());
-                getCommandFunctions().forEach(commandCreator ->
-                   executeCommand(binding, operationContextWithMinRtt, databaseName, commandCreator.get(), connection,
-                          writeConcernErrorTransformer(operationContextWithMinRtt.getTimeoutContext()))
-                );
-                return null;
+        return withWriteConnectionSource(binding, operationContext, (source, operationContextWithMinRtt) -> {
+            getCommandFunctions().forEach(commandCreator -> {
+                RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContextWithMinRtt);
+                Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContextWithMinRtt, () -> {
+                    retryControl.getPolicy().onCommand(this::getCommandName);
+                    return withConnection(source, operationContextWithMinRtt, (connection, connectionScopedOperationContext) -> {
+                        checkEncryptedFieldsSupported(connection.getDescription());
+                        executeCommand(binding, connectionScopedOperationContext, databaseName, commandCreator.get(), connection,
+                                writeConcernErrorTransformer(connectionScopedOperationContext.getTimeoutContext()));
+                        return null;
+                    });
+                });
+                retryingCommandExecutor.get();
             });
+            return null;
         });
-        return retryingCommandExecutor.get();
     }
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
-        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
-                operationContext);
-        AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback ->
-                withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
-                    SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(supplierCallback, LOGGER);
-                    if (t != null) {
-                        errHandlingCallback.onResult(null, t);
-                    } else {
-                        SingleResultCallback<Void> releasingCallback = releasingCallback(errHandlingCallback, connection);
-                        if (!checkEncryptedFieldsSupported(connection.getDescription(), releasingCallback)) {
-                            return;
-                        }
-                        new ProcessCommandsCallback(binding, operationContextWithMinRtt, connection, releasingCallback)
-                                .onResult(null, null);
-                    }
-                }));
-        retryingCommandExecutor.get(callback);
+        withAsyncWriteConnectionSource(binding, operationContext, callback,
+                (source, operationContextWithMinRtt, sourceReleasingCallback) ->
+                        new ProcessCommandsCallback(binding, source, operationContextWithMinRtt, sourceReleasingCallback)
+                                .onResult(null, null));
+    }
+
+    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
+        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
     }
 
     private String getGranularityAsString(final TimeSeriesGranularity granularity) {
@@ -444,15 +433,15 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
     class ProcessCommandsCallback implements SingleResultCallback<Void> {
         private final AsyncWriteBinding binding;
         private final OperationContext operationContext;
-        private final AsyncConnection connection;
+        private final AsyncConnectionSource source;
         private final SingleResultCallback<Void>  finalCallback;
         private final Deque<Supplier<BsonDocument>> commands;
 
         ProcessCommandsCallback(
-                final AsyncWriteBinding binding, final OperationContext operationContext, final AsyncConnection connection, final SingleResultCallback<Void> finalCallback) {
+                final AsyncWriteBinding binding, final AsyncConnectionSource source, final OperationContext operationContext, final SingleResultCallback<Void> finalCallback) {
             this.binding = binding;
+            this.source = source;
             this.operationContext = operationContext;
-            this.connection = connection;
             this.finalCallback = finalCallback;
             this.commands = new ArrayDeque<>(getCommandFunctions());
         }
@@ -467,8 +456,22 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
             if (nextCommandFunction == null) {
                 finalCallback.onResult(null, null);
             } else {
-                executeCommandAsync(binding, operationContext,  databaseName, nextCommandFunction.get(),
-                        connection, writeConcernErrorTransformerAsync(operationContext.getTimeoutContext()), this);
+                RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContext);
+                AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext,
+                        supplierCallback -> {
+                            retryControl.getPolicy().onCommand(CreateCollectionOperation.this::getCommandName);
+                            withAsyncConnection(source, operationContext, supplierCallback,
+                                    (connection, connectionScopedOperationContext, connectionReleasingCallback) -> {
+                                        if (!checkEncryptedFieldsSupported(connection.getDescription(), connectionReleasingCallback)) {
+                                            return;
+                                        }
+                                        executeCommandAsync(binding, connectionScopedOperationContext, databaseName,
+                                                nextCommandFunction.get(), connection,
+                                                writeConcernErrorTransformerAsync(connectionScopedOperationContext.getTimeoutContext()),
+                                                connectionReleasingCallback);
+                                    });
+                        });
+                retryingCommandExecutor.get(this);
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
@@ -28,6 +28,8 @@ import com.mongodb.client.model.ValidationAction;
 import com.mongodb.client.model.ValidationLevel;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
+import com.mongodb.internal.async.function.RetryControl;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
 import com.mongodb.internal.connection.AsyncConnection;
@@ -47,15 +49,18 @@ import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
+import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWithRetriesAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncConnection;
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.DocumentHelper.putIfFalse;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsLessThanVersionSevenDotZero;
+import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
 import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErrorTransformer;
@@ -76,6 +81,9 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
     private final String databaseName;
     private final String collectionName;
     private final WriteConcern writeConcern;
+    private final boolean retryWrites;
+    @Nullable
+    private final Integer maxAdaptiveRetriesSetting;
     private boolean capped = false;
     private long sizeInBytes = 0;
     private boolean autoIndex = true;
@@ -95,9 +103,20 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
     private BsonDocument encryptedFields;
 
     public CreateCollectionOperation(final String databaseName, final String collectionName, @Nullable final WriteConcern writeConcern) {
+        this(databaseName, collectionName, writeConcern, false, null);
+    }
+
+    /**
+     * @param retryWrites Whether overload retries are enabled for this operation.
+     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
+     */
+    public CreateCollectionOperation(final String databaseName, final String collectionName, @Nullable final WriteConcern writeConcern,
+            final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.databaseName = notNull("databaseName", databaseName);
         this.collectionName = notNull("collectionName", collectionName);
         this.writeConcern = writeConcern;
+        this.retryWrites = retryWrites;
+        this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
     }
 
     public String getCollectionName() {
@@ -245,31 +264,45 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
 
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
-        return withConnection(binding, operationContext, (connection, operationContextWithMinRtt)-> {
-            checkEncryptedFieldsSupported(connection.getDescription());
-            getCommandFunctions().forEach(commandCreator ->
-               executeCommand(binding, operationContextWithMinRtt,  databaseName, commandCreator.get(), connection,
-                      writeConcernErrorTransformer(operationContextWithMinRtt.getTimeoutContext()))
-            );
-            return null;
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
+            retryControl.getPolicy().onCommand(this::getCommandName);
+            return withConnection(binding, operationContext, (connection, operationContextWithMinRtt) -> {
+                checkEncryptedFieldsSupported(connection.getDescription());
+                getCommandFunctions().forEach(commandCreator ->
+                   executeCommand(binding, operationContextWithMinRtt, databaseName, commandCreator.get(), connection,
+                          writeConcernErrorTransformer(operationContextWithMinRtt.getTimeoutContext()))
+                );
+                return null;
+            });
         });
+        return retryingCommandExecutor.get();
     }
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
-        withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
-            SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
-            if (t != null) {
-                errHandlingCallback.onResult(null, t);
-            } else {
-                SingleResultCallback<Void> releasingCallback = releasingCallback(errHandlingCallback, connection);
-                if (!checkEncryptedFieldsSupported(connection.getDescription(), releasingCallback)) {
-                    return;
-                }
-                new ProcessCommandsCallback(binding, operationContextWithMinRtt, connection, releasingCallback)
-                        .onResult(null, null);
-            }
-        });
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback ->
+                withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
+                    SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(supplierCallback, LOGGER);
+                    if (t != null) {
+                        errHandlingCallback.onResult(null, t);
+                    } else {
+                        SingleResultCallback<Void> releasingCallback = releasingCallback(errHandlingCallback, connection);
+                        if (!checkEncryptedFieldsSupported(connection.getDescription(), releasingCallback)) {
+                            return;
+                        }
+                        new ProcessCommandsCallback(binding, operationContextWithMinRtt, connection, releasingCallback)
+                                .onResult(null, null);
+                    }
+                }));
+        retryingCommandExecutor.get(callback);
     }
 
     private String getGranularityAsString(final TimeSeriesGranularity granularity) {

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
@@ -103,10 +103,6 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
         this(databaseName, collectionName, writeConcern, false, null);
     }
 
-    /**
-     * @param retryWrites Whether overload retries are enabled for this operation.
-     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
-     */
     public CreateCollectionOperation(final String databaseName, final String collectionName, @Nullable final WriteConcern writeConcern,
             final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.databaseName = notNull("databaseName", databaseName);

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
@@ -30,7 +30,6 @@ import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.function.AsyncCallbackSupplier;
 import com.mongodb.internal.async.function.RetryControl;
-import com.mongodb.internal.binding.AsyncConnectionSource;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
 import com.mongodb.internal.connection.OperationContext;
@@ -50,8 +49,8 @@ import java.util.function.Supplier;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWithRetriesAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync;
+import static com.mongodb.internal.operation.AsyncOperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncConnection;
-import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncWriteConnectionSource;
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
 import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.DocumentHelper.putIfFalse;
@@ -61,7 +60,6 @@ import static com.mongodb.internal.operation.ServerVersionHelper.serverIsLessTha
 import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
-import static com.mongodb.internal.operation.SyncOperationHelper.withWriteConnectionSource;
 import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErrorTransformer;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static java.util.Arrays.asList;
@@ -263,56 +261,25 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
 
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
-        List<Supplier<BsonDocument>> commandFunctions = getCommandFunctions();
-        if (commandFunctions.size() == 1) {
-            Supplier<BsonDocument> commandCreator = commandFunctions.get(0);
+        getCommandFunctions().forEach(commandCreator -> {
             RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContext);
             Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
                 retryControl.getPolicy().onCommand(this::getCommandName);
-                return executeCommand(binding, operationContext, databaseName,
-                        (operationContext1, serverDescription, connectionDescription) -> commandCreator.get(),
-                        writeConcernErrorTransformer(operationContext.getTimeoutContext()));
-            });
-            return retryingCommandExecutor.get();
-        }
-        return withWriteConnectionSource(binding, operationContext, (source, operationContextWithMinRtt) -> {
-            commandFunctions.forEach(commandCreator -> {
-                RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContextWithMinRtt);
-                Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContextWithMinRtt, () -> {
-                    retryControl.getPolicy().onCommand(this::getCommandName);
-                    return withConnection(source, operationContextWithMinRtt, (connection, connectionScopedOperationContext) -> {
-                        checkEncryptedFieldsSupported(connection.getDescription());
-                        executeCommand(binding, connectionScopedOperationContext, databaseName, commandCreator.get(), connection,
-                                writeConcernErrorTransformer(connectionScopedOperationContext.getTimeoutContext()));
-                        return null;
-                    });
+                return withConnection(binding, operationContext, (connection, connectionScopedOperationContext) -> {
+                    checkEncryptedFieldsSupported(connection.getDescription());
+                    executeCommand(binding, connectionScopedOperationContext, databaseName, commandCreator.get(), connection,
+                            writeConcernErrorTransformer(connectionScopedOperationContext.getTimeoutContext()));
+                    return null;
                 });
-                retryingCommandExecutor.get();
             });
-            return null;
+            retryingCommandExecutor.get();
         });
+        return null;
     }
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
-        List<Supplier<BsonDocument>> commandFunctions = getCommandFunctions();
-        if (commandFunctions.size() == 1) {
-            Supplier<BsonDocument> commandCreator = commandFunctions.get(0);
-            RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContext);
-            AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback -> {
-                retryControl.getPolicy().onCommand(this::getCommandName);
-                executeCommandAsync(binding, operationContext, databaseName,
-                        (operationContext1, serverDescription, connectionDescription) -> commandCreator.get(),
-                        writeConcernErrorTransformerAsync(operationContext.getTimeoutContext()),
-                        supplierCallback);
-            });
-            retryingCommandExecutor.get(callback);
-        } else {
-            withAsyncWriteConnectionSource(binding, operationContext, callback,
-                    (source, operationContextWithMinRtt, sourceReleasingCallback) ->
-                            new ProcessCommandsCallback(binding, source, operationContextWithMinRtt, sourceReleasingCallback)
-                                    .onResult(null, null));
-        }
+        new ProcessCommandsCallback(binding, operationContext, callback).onResult(null, null);
     }
 
     private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
@@ -459,14 +426,12 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
     class ProcessCommandsCallback implements SingleResultCallback<Void> {
         private final AsyncWriteBinding binding;
         private final OperationContext operationContext;
-        private final AsyncConnectionSource source;
         private final SingleResultCallback<Void>  finalCallback;
         private final Deque<Supplier<BsonDocument>> commands;
 
         ProcessCommandsCallback(
-                final AsyncWriteBinding binding, final AsyncConnectionSource source, final OperationContext operationContext, final SingleResultCallback<Void> finalCallback) {
+                final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> finalCallback) {
             this.binding = binding;
-            this.source = source;
             this.operationContext = operationContext;
             this.finalCallback = finalCallback;
             this.commands = new ArrayDeque<>(getCommandFunctions());
@@ -486,16 +451,20 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
                 AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext,
                         supplierCallback -> {
                             retryControl.getPolicy().onCommand(CreateCollectionOperation.this::getCommandName);
-                            withAsyncConnection(source, operationContext, supplierCallback,
-                                    (connection, connectionScopedOperationContext, connectionReleasingCallback) -> {
-                                        if (!checkEncryptedFieldsSupported(connection.getDescription(), connectionReleasingCallback)) {
-                                            return;
-                                        }
-                                        executeCommandAsync(binding, connectionScopedOperationContext, databaseName,
-                                                nextCommandFunction.get(), connection,
-                                                writeConcernErrorTransformerAsync(connectionScopedOperationContext.getTimeoutContext()),
-                                                connectionReleasingCallback);
-                                    });
+                            withAsyncConnection(binding, operationContext, (connection, connectionScopedOperationContext, t1) -> {
+                                if (t1 != null) {
+                                    supplierCallback.onResult(null, t1);
+                                } else {
+                                    SingleResultCallback<Void> connectionReleasingCallback = releasingCallback(supplierCallback, connection);
+                                    if (!checkEncryptedFieldsSupported(connection.getDescription(), connectionReleasingCallback)) {
+                                        return;
+                                    }
+                                    executeCommandAsync(binding, connectionScopedOperationContext, databaseName,
+                                            nextCommandFunction.get(), connection,
+                                            writeConcernErrorTransformerAsync(connectionScopedOperationContext.getTimeoutContext()),
+                                            connectionReleasingCallback);
+                                }
+                            });
                         });
                 retryingCommandExecutor.get(this);
             }

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
@@ -57,6 +57,7 @@ import static com.mongodb.internal.operation.DocumentHelper.putIfFalse;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsLessThanVersionSevenDotZero;
+import static com.mongodb.internal.operation.SpecRetryPolicy.IndividualPolicies.overloadForWrite;
 import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
@@ -258,7 +259,8 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         getCommandFunctions().forEach(commandCreator -> {
-            RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContext);
+            RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(overloadForWrite(retryWrites, maxAdaptiveRetriesSetting),
+                    operationContext);
             Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
                 retryControl.getPolicy().onCommand(this::getCommandName);
                 return withConnection(binding, operationContext, (connection, connectionScopedOperationContext) -> {
@@ -276,11 +278,6 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
         new ProcessCommandsCallback(binding, operationContext, callback).onResult(null, null);
-    }
-
-    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
-        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
     }
 
     private String getGranularityAsString(final TimeSeriesGranularity granularity) {
@@ -443,7 +440,8 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
             if (nextCommandFunction == null) {
                 finalCallback.onResult(null, null);
             } else {
-                RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContext);
+                RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                        overloadForWrite(retryWrites, maxAdaptiveRetriesSetting), operationContext);
                 AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext,
                         supplierCallback -> {
                             retryControl.getPolicy().onCommand(CreateCollectionOperation.this::getCommandName);

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
@@ -263,8 +263,20 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
 
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
+        List<Supplier<BsonDocument>> commandFunctions = getCommandFunctions();
+        if (commandFunctions.size() == 1) {
+            Supplier<BsonDocument> commandCreator = commandFunctions.get(0);
+            RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContext);
+            Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
+                retryControl.getPolicy().onCommand(this::getCommandName);
+                return executeCommand(binding, operationContext, databaseName,
+                        (operationContext1, serverDescription, connectionDescription) -> commandCreator.get(),
+                        writeConcernErrorTransformer(operationContext.getTimeoutContext()));
+            });
+            return retryingCommandExecutor.get();
+        }
         return withWriteConnectionSource(binding, operationContext, (source, operationContextWithMinRtt) -> {
-            getCommandFunctions().forEach(commandCreator -> {
+            commandFunctions.forEach(commandCreator -> {
                 RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContextWithMinRtt);
                 Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContextWithMinRtt, () -> {
                     retryControl.getPolicy().onCommand(this::getCommandName);
@@ -283,10 +295,24 @@ public class CreateCollectionOperation implements WriteOperation<Void> {
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
-        withAsyncWriteConnectionSource(binding, operationContext, callback,
-                (source, operationContextWithMinRtt, sourceReleasingCallback) ->
-                        new ProcessCommandsCallback(binding, source, operationContextWithMinRtt, sourceReleasingCallback)
-                                .onResult(null, null));
+        List<Supplier<BsonDocument>> commandFunctions = getCommandFunctions();
+        if (commandFunctions.size() == 1) {
+            Supplier<BsonDocument> commandCreator = commandFunctions.get(0);
+            RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContext);
+            AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback -> {
+                retryControl.getPolicy().onCommand(this::getCommandName);
+                executeCommandAsync(binding, operationContext, databaseName,
+                        (operationContext1, serverDescription, connectionDescription) -> commandCreator.get(),
+                        writeConcernErrorTransformerAsync(operationContext.getTimeoutContext()),
+                        supplierCallback);
+            });
+            retryingCommandExecutor.get(callback);
+        } else {
+            withAsyncWriteConnectionSource(binding, operationContext, callback,
+                    (source, operationContextWithMinRtt, sourceReleasingCallback) ->
+                            new ProcessCommandsCallback(binding, source, operationContextWithMinRtt, sourceReleasingCallback)
+                                    .onResult(null, null));
+        }
     }
 
     private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateIndexesOperation.java
@@ -135,8 +135,7 @@ public class CreateIndexesOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -153,8 +152,7 @@ public class CreateIndexesOperation implements WriteOperation<Void> {
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 operationContext);
         AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -268,5 +266,10 @@ public class CreateIndexesOperation implements WriteOperation<Void> {
         } else {
             return e;
         }
+    }
+
+    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
+        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateIndexesOperation.java
@@ -79,10 +79,6 @@ public class CreateIndexesOperation implements WriteOperation<Void> {
         this(namespace, requests, writeConcern, false, null);
     }
 
-    /**
-     * @param retryWrites Whether overload retries are enabled for this operation.
-     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
-     */
     public CreateIndexesOperation(final MongoNamespace namespace, final List<IndexRequest> requests,
             @Nullable final WriteConcern writeConcern, final boolean retryWrites,
             @Nullable final Integer maxAdaptiveRetriesSetting) {

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateIndexesOperation.java
@@ -26,6 +26,8 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteConcernResult;
 import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
+import com.mongodb.internal.async.function.RetryControl;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
 import com.mongodb.internal.bulk.IndexRequest;
@@ -42,13 +44,17 @@ import org.bson.BsonString;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWithRetriesAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.IndexHelper.generateIndexName;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionFourDotFour;
+import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErrorTransformer;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
@@ -63,13 +69,28 @@ public class CreateIndexesOperation implements WriteOperation<Void> {
     private final MongoNamespace namespace;
     private final List<IndexRequest> requests;
     private final WriteConcern writeConcern;
+    private final boolean retryWrites;
+    @Nullable
+    private final Integer maxAdaptiveRetriesSetting;
     private CreateIndexCommitQuorum commitQuorum;
 
     public CreateIndexesOperation(final MongoNamespace namespace, final List<IndexRequest> requests,
             @Nullable final WriteConcern writeConcern) {
+        this(namespace, requests, writeConcern, false, null);
+    }
+
+    /**
+     * @param retryWrites Whether overload retries are enabled for this operation.
+     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
+     */
+    public CreateIndexesOperation(final MongoNamespace namespace, final List<IndexRequest> requests,
+            @Nullable final WriteConcern writeConcern, final boolean retryWrites,
+            @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.namespace = notNull("namespace", namespace);
         this.requests = notNull("indexRequests", requests);
         this.writeConcern = writeConcern;
+        this.retryWrites = retryWrites;
+        this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
     }
 
     public WriteConcern getWriteConcern() {
@@ -113,9 +134,17 @@ public class CreateIndexesOperation implements WriteOperation<Void> {
 
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
+            retryControl.getPolicy().onCommand(this::getCommandName);
+            return executeCommand(binding, operationContext, namespace.getDatabaseName(), getCommandCreator(),
+                    writeConcernErrorTransformer(operationContext.getTimeoutContext()));
+        });
         try {
-            return executeCommand(binding, operationContext,  namespace.getDatabaseName(), getCommandCreator(), writeConcernErrorTransformer(
-                    operationContext.getTimeoutContext()));
+            return retryingCommandExecutor.get();
         } catch (MongoCommandException e) {
             throw checkForDuplicateKeyError(e);
         }
@@ -123,14 +152,22 @@ public class CreateIndexesOperation implements WriteOperation<Void> {
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
-        executeCommandAsync(binding, operationContext,  namespace.getDatabaseName(), getCommandCreator(), writeConcernErrorTransformerAsync(operationContext.getTimeoutContext()),
-                ((result, t) -> {
-                    if (t != null) {
-                        callback.onResult(null, translateException(t));
-                    } else {
-                        callback.onResult(result, null);
-                    }
-                }));
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback -> {
+            retryControl.getPolicy().onCommand(this::getCommandName);
+            executeCommandAsync(binding, operationContext, namespace.getDatabaseName(), getCommandCreator(),
+                    writeConcernErrorTransformerAsync(operationContext.getTimeoutContext()), supplierCallback);
+        });
+        retryingCommandExecutor.get((result, t) -> {
+            if (t != null) {
+                callback.onResult(null, translateException(t));
+            } else {
+                callback.onResult(result, null);
+            }
+        });
     }
 
     @SuppressWarnings("deprecation")

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateIndexesOperation.java
@@ -54,6 +54,7 @@ import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernEr
 import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.IndexHelper.generateIndexName;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionFourDotFour;
+import static com.mongodb.internal.operation.SpecRetryPolicy.IndividualPolicies.overloadForWrite;
 import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErrorTransformer;
@@ -131,7 +132,7 @@ public class CreateIndexesOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                createSpecRetryPolicy(),
+                overloadForWrite(retryWrites, maxAdaptiveRetriesSetting),
                 operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -148,7 +149,7 @@ public class CreateIndexesOperation implements WriteOperation<Void> {
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                createSpecRetryPolicy(),
+                overloadForWrite(retryWrites, maxAdaptiveRetriesSetting),
                 operationContext);
         AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -264,8 +265,4 @@ public class CreateIndexesOperation implements WriteOperation<Void> {
         }
     }
 
-    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
-        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
-    }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateSearchIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateSearchIndexesOperation.java
@@ -41,10 +41,6 @@ public final class CreateSearchIndexesOperation extends AbstractWriteSearchIndex
         this(namespace, indexRequests, false, null);
     }
 
-    /**
-     * @param retryWrites Whether overload retries are enabled for this operation.
-     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
-     */
     public CreateSearchIndexesOperation(final MongoNamespace namespace, final List<SearchIndexRequest> indexRequests,
             final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         super(namespace, retryWrites, maxAdaptiveRetriesSetting);

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateSearchIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateSearchIndexesOperation.java
@@ -18,6 +18,7 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.model.SearchIndexType;
+import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
@@ -37,7 +38,16 @@ public final class CreateSearchIndexesOperation extends AbstractWriteSearchIndex
     private final List<SearchIndexRequest> indexRequests;
 
     public CreateSearchIndexesOperation(final MongoNamespace namespace, final List<SearchIndexRequest> indexRequests) {
-        super(namespace);
+        this(namespace, indexRequests, false, null);
+    }
+
+    /**
+     * @param retryWrites Whether overload retries are enabled for this operation.
+     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
+     */
+    public CreateSearchIndexesOperation(final MongoNamespace namespace, final List<SearchIndexRequest> indexRequests,
+            final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
+        super(namespace, retryWrites, maxAdaptiveRetriesSetting);
         this.indexRequests = assertNotNull(indexRequests);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateViewOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateViewOperation.java
@@ -158,8 +158,7 @@ public class CreateViewOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -175,8 +174,7 @@ public class CreateViewOperation implements WriteOperation<Void> {
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 operationContext);
         AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback ->
                 withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
@@ -203,5 +201,10 @@ public class CreateViewOperation implements WriteOperation<Void> {
 
         appendWriteConcernToCommand(writeConcern, commandDocument);
         return commandDocument;
+    }
+
+    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
+        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateViewOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateViewOperation.java
@@ -43,6 +43,7 @@ import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncConne
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
 import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
+import static com.mongodb.internal.operation.SpecRetryPolicy.IndividualPolicies.overloadForWrite;
 import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
@@ -154,7 +155,7 @@ public class CreateViewOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                createSpecRetryPolicy(),
+                overloadForWrite(retryWrites, maxAdaptiveRetriesSetting),
                 operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -170,7 +171,7 @@ public class CreateViewOperation implements WriteOperation<Void> {
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                createSpecRetryPolicy(),
+                overloadForWrite(retryWrites, maxAdaptiveRetriesSetting),
                 operationContext);
         AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback ->
                 withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
@@ -199,8 +200,4 @@ public class CreateViewOperation implements WriteOperation<Void> {
         return commandDocument;
     }
 
-    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
-        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
-    }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateViewOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateViewOperation.java
@@ -20,6 +20,8 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
 import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
+import com.mongodb.internal.async.function.RetryControl;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
 import com.mongodb.internal.connection.OperationContext;
@@ -30,14 +32,18 @@ import org.bson.BsonString;
 import org.bson.codecs.BsonDocumentCodec;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
+import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWithRetriesAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncConnection;
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
+import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
 import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErrorTransformer;
@@ -54,15 +60,29 @@ public class CreateViewOperation implements WriteOperation<Void> {
     private final String viewOn;
     private final List<BsonDocument> pipeline;
     private final WriteConcern writeConcern;
+    private final boolean retryWrites;
+    @Nullable
+    private final Integer maxAdaptiveRetriesSetting;
     private Collation collation;
 
     public CreateViewOperation(final String databaseName, final String viewName, final String viewOn, final List<BsonDocument> pipeline,
             final WriteConcern writeConcern) {
+        this(databaseName, viewName, viewOn, pipeline, writeConcern, false, null);
+    }
+
+    /**
+     * @param retryWrites Whether overload retries are enabled for this operation.
+     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
+     */
+    public CreateViewOperation(final String databaseName, final String viewName, final String viewOn, final List<BsonDocument> pipeline,
+            final WriteConcern writeConcern, final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.databaseName = notNull("databaseName", databaseName);
         this.viewName = notNull("viewName", viewName);
         this.viewOn = notNull("viewOn", viewOn);
         this.pipeline = notNull("pipeline", pipeline);
         this.writeConcern = notNull("writeConcern", writeConcern);
+        this.retryWrites = retryWrites;
+        this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
     }
 
     public String getDatabaseName() {
@@ -137,26 +157,40 @@ public class CreateViewOperation implements WriteOperation<Void> {
 
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
-        return withConnection(binding, operationContext, (connection, operationContextWithMinRtt) -> {
-            executeCommand(binding, operationContextWithMinRtt,  databaseName, getCommand(), new BsonDocumentCodec(),
-                    writeConcernErrorTransformer(operationContextWithMinRtt.getTimeoutContext()));
-            return null;
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
+            retryControl.getPolicy().onCommand(this::getCommandName);
+            return withConnection(binding, operationContext, (connection, operationContextWithMinRtt) -> {
+                executeCommand(binding, operationContextWithMinRtt,  databaseName, getCommand(), new BsonDocumentCodec(),
+                        writeConcernErrorTransformer(operationContextWithMinRtt.getTimeoutContext()));
+                return null;
+            });
         });
+        return retryingCommandExecutor.get();
     }
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
-        withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
-            SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
-            if (t != null) {
-                errHandlingCallback.onResult(null, t);
-            } else {
-                SingleResultCallback<Void> wrappedCallback = releasingCallback(errHandlingCallback, connection);
-                executeCommandAsync(binding, operationContextWithMinRtt,  databaseName, getCommand(), connection,
-                        writeConcernErrorTransformerAsync(operationContextWithMinRtt.getTimeoutContext()),
-                        wrappedCallback);
-            }
-        });
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback ->
+                withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
+                    SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(supplierCallback, LOGGER);
+                    if (t != null) {
+                        errHandlingCallback.onResult(null, t);
+                    } else {
+                        SingleResultCallback<Void> wrappedCallback = releasingCallback(errHandlingCallback, connection);
+                        executeCommandAsync(binding, operationContextWithMinRtt,  databaseName, getCommand(), connection,
+                                writeConcernErrorTransformerAsync(operationContextWithMinRtt.getTimeoutContext()),
+                                wrappedCallback);
+                    }
+                }));
+        retryingCommandExecutor.get(callback);
     }
 
     private BsonDocument getCommand() {

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateViewOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateViewOperation.java
@@ -70,10 +70,6 @@ public class CreateViewOperation implements WriteOperation<Void> {
         this(databaseName, viewName, viewOn, pipeline, writeConcern, false, null);
     }
 
-    /**
-     * @param retryWrites Whether overload retries are enabled for this operation.
-     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
-     */
     public CreateViewOperation(final String databaseName, final String viewName, final String viewOn, final List<BsonDocument> pipeline,
             final WriteConcern writeConcern, final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.databaseName = notNull("databaseName", databaseName);

--- a/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
@@ -21,6 +21,8 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.MongoOperationTimeoutException;
 import com.mongodb.WriteConcern;
 import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
+import com.mongodb.internal.async.function.RetryControl;
 import com.mongodb.internal.binding.AsyncReadWriteBinding;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.ReadWriteBinding;
@@ -40,13 +42,16 @@ import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
+import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWithRetriesAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncConnection;
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceError;
 import static com.mongodb.internal.operation.CommandOperationHelper.rethrowIfNotNamespaceError;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
+import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
 import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErrorTransformer;
@@ -65,12 +70,26 @@ public class DropCollectionOperation implements WriteOperation<Void> {
     private static final BsonValueCodec BSON_VALUE_CODEC = new BsonValueCodec();
     private final MongoNamespace namespace;
     private final WriteConcern writeConcern;
+    private final boolean retryWrites;
+    @Nullable
+    private final Integer maxAdaptiveRetriesSetting;
     private BsonDocument encryptedFields;
     private boolean autoEncryptedFields;
 
     public DropCollectionOperation(final MongoNamespace namespace, @Nullable final WriteConcern writeConcern) {
+        this(namespace, writeConcern, false, null);
+    }
+
+    /**
+     * @param retryWrites Whether overload retries are enabled for this operation.
+     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
+     */
+    public DropCollectionOperation(final MongoNamespace namespace, @Nullable final WriteConcern writeConcern,
+            final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.namespace = notNull("namespace", namespace);
         this.writeConcern = writeConcern;
+        this.retryWrites = retryWrites;
+        this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
     }
 
     public WriteConcern getWriteConcern() {
@@ -100,39 +119,54 @@ public class DropCollectionOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         BsonDocument localEncryptedFields = getEncryptedFields((ReadWriteBinding) binding, operationContext);
-        return withConnection(binding, operationContext, (connection, operationContextWithMinRtt) -> {
-            getCommands(localEncryptedFields).forEach(command -> {
-                try {
-                    executeCommand(binding, operationContextWithMinRtt, namespace.getDatabaseName(), command.get(),
-                            connection, writeConcernErrorTransformer(operationContextWithMinRtt.getTimeoutContext()));
-                } catch (MongoCommandException e) {
-                    rethrowIfNotNamespaceError(e);
-                }
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
+            retryControl.getPolicy().onCommand(this::getCommandName);
+            return withConnection(binding, operationContext, (connection, operationContextWithMinRtt) -> {
+                getCommands(localEncryptedFields).forEach(command -> {
+                    try {
+                        executeCommand(binding, operationContextWithMinRtt, namespace.getDatabaseName(), command.get(),
+                                connection, writeConcernErrorTransformer(operationContextWithMinRtt.getTimeoutContext()));
+                    } catch (MongoCommandException e) {
+                        rethrowIfNotNamespaceError(e);
+                    }
+                });
+                return null;
             });
-            return null;
         });
+        return retryingCommandExecutor.get();
     }
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext,
                              final SingleResultCallback<Void> callback) {
-        SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
-        getEncryptedFields((AsyncReadWriteBinding) binding, operationContext, (result, t) -> {
-            if (t != null) {
-                errHandlingCallback.onResult(null, t);
-            } else {
-                withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t1) -> {
-                    if (t1 != null) {
-                        errHandlingCallback.onResult(null, t1);
-                    } else {
-                        new ProcessCommandsCallback(binding, operationContextWithMinRtt, connection, getCommands(result),
-                                releasingCallback(errHandlingCallback,
-                                connection))
-                                .onResult(null, null);
-                    }
-                });
-            }
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback -> {
+            SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(supplierCallback, LOGGER);
+            getEncryptedFields((AsyncReadWriteBinding) binding, operationContext, (result, t) -> {
+                if (t != null) {
+                    errHandlingCallback.onResult(null, t);
+                } else {
+                    withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t1) -> {
+                        if (t1 != null) {
+                            errHandlingCallback.onResult(null, t1);
+                        } else {
+                            new ProcessCommandsCallback(binding, operationContextWithMinRtt, connection, getCommands(result),
+                                    releasingCallback(errHandlingCallback,
+                                    connection))
+                                    .onResult(null, null);
+                        }
+                    });
+                }
+            });
         });
+        retryingCommandExecutor.get(callback);
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
@@ -120,8 +120,7 @@ public class DropCollectionOperation implements WriteOperation<Void> {
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         BsonDocument localEncryptedFields = getEncryptedFields((ReadWriteBinding) binding, operationContext);
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -144,8 +143,7 @@ public class DropCollectionOperation implements WriteOperation<Void> {
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext,
                              final SingleResultCallback<Void> callback) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 operationContext);
         AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback -> {
             SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(supplierCallback, LOGGER);
@@ -310,4 +308,9 @@ public class DropCollectionOperation implements WriteOperation<Void> {
         }
     }
 
+
+    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
+        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
+    }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
@@ -49,6 +49,7 @@ import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRe
 import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceError;
 import static com.mongodb.internal.operation.CommandOperationHelper.rethrowIfNotNamespaceError;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
+import static com.mongodb.internal.operation.SpecRetryPolicy.IndividualPolicies.overloadForWrite;
 import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
@@ -114,7 +115,8 @@ public class DropCollectionOperation implements WriteOperation<Void> {
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         BsonDocument localEncryptedFields = getEncryptedFields((ReadWriteBinding) binding, operationContext);
         getCommands(localEncryptedFields).forEach(commandCreator -> {
-            RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContext);
+            RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                    overloadForWrite(retryWrites, maxAdaptiveRetriesSetting), operationContext);
             Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
                 retryControl.getPolicy().onCommand(this::getCommandName);
                 return withConnection(binding, operationContext, (connection, connectionScopedOperationContext) -> {
@@ -272,7 +274,8 @@ public class DropCollectionOperation implements WriteOperation<Void> {
             if (nextCommandFunction == null) {
                 finalCallback.onResult(null, null);
             } else {
-                RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContext);
+                RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                    overloadForWrite(retryWrites, maxAdaptiveRetriesSetting), operationContext);
                 AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext,
                         supplierCallback -> {
                             retryControl.getPolicy().onCommand(DropCollectionOperation.this::getCommandName);
@@ -294,8 +297,4 @@ public class DropCollectionOperation implements WriteOperation<Void> {
     }
 
 
-    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
-        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
-    }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
@@ -78,10 +78,6 @@ public class DropCollectionOperation implements WriteOperation<Void> {
         this(namespace, writeConcern, false, null);
     }
 
-    /**
-     * @param retryWrites Whether overload retries are enabled for this operation.
-     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
-     */
     public DropCollectionOperation(final MongoNamespace namespace, @Nullable final WriteConcern writeConcern,
             final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.namespace = notNull("namespace", namespace);

--- a/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
@@ -18,16 +18,15 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
-import com.mongodb.MongoOperationTimeoutException;
 import com.mongodb.WriteConcern;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.function.AsyncCallbackSupplier;
 import com.mongodb.internal.async.function.RetryControl;
+import com.mongodb.internal.binding.AsyncConnectionSource;
 import com.mongodb.internal.binding.AsyncReadWriteBinding;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.ReadWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
-import com.mongodb.internal.connection.AsyncConnection;
 import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
@@ -44,8 +43,8 @@ import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWithRetriesAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync;
-import static com.mongodb.internal.operation.AsyncOperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncConnection;
+import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncWriteConnectionSource;
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
 import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceError;
@@ -54,6 +53,7 @@ import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
+import static com.mongodb.internal.operation.SyncOperationHelper.withWriteConnectionSource;
 import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErrorTransformer;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static java.util.Arrays.asList;
@@ -119,24 +119,25 @@ public class DropCollectionOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         BsonDocument localEncryptedFields = getEncryptedFields((ReadWriteBinding) binding, operationContext);
-        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                createSpecRetryPolicy(),
-                operationContext);
-        Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
-            retryControl.getPolicy().onCommand(this::getCommandName);
-            return withConnection(binding, operationContext, (connection, operationContextWithMinRtt) -> {
-                getCommands(localEncryptedFields).forEach(command -> {
-                    try {
-                        executeCommand(binding, operationContextWithMinRtt, namespace.getDatabaseName(), command.get(),
-                                connection, writeConcernErrorTransformer(operationContextWithMinRtt.getTimeoutContext()));
-                    } catch (MongoCommandException e) {
-                        rethrowIfNotNamespaceError(e);
-                    }
+        return withWriteConnectionSource(binding, operationContext, (source, operationContextWithMinRtt) -> {
+            getCommands(localEncryptedFields).forEach(commandCreator -> {
+                RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContextWithMinRtt);
+                Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContextWithMinRtt, () -> {
+                    retryControl.getPolicy().onCommand(this::getCommandName);
+                    return withConnection(source, operationContextWithMinRtt, (connection, connectionScopedOperationContext) -> {
+                        try {
+                            executeCommand(binding, connectionScopedOperationContext, namespace.getDatabaseName(), commandCreator.get(),
+                                    connection, writeConcernErrorTransformer(connectionScopedOperationContext.getTimeoutContext()));
+                        } catch (MongoCommandException e) {
+                            rethrowIfNotNamespaceError(e);
+                        }
+                        return null;
+                    });
                 });
-                return null;
+                retryingCommandExecutor.get();
             });
+            return null;
         });
-        return retryingCommandExecutor.get();
     }
 
     @Override
@@ -147,24 +148,10 @@ public class DropCollectionOperation implements WriteOperation<Void> {
                 errorHandlingCallback(callback, LOGGER).onResult(null, t);
                 return;
             }
-            RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                    createSpecRetryPolicy(),
-                    operationContext);
-            AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext,
-                    supplierCallback -> {
-                        SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(supplierCallback, LOGGER);
-                        withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t1) -> {
-                            if (t1 != null) {
-                                errHandlingCallback.onResult(null, t1);
-                            } else {
-                                new ProcessCommandsCallback(binding, operationContextWithMinRtt, connection,
-                                        getCommands(localEncryptedFields),
-                                        releasingCallback(errHandlingCallback, connection))
-                                        .onResult(null, null);
-                            }
-                        });
-                    });
-            retryingCommandExecutor.get(callback);
+            withAsyncWriteConnectionSource(binding, operationContext, callback,
+                    (source, operationContextWithMinRtt, sourceReleasingCallback) ->
+                            new ProcessCommandsCallback(binding, source, operationContextWithMinRtt,
+                                    getCommands(localEncryptedFields), sourceReleasingCallback).onResult(null, null));
         });
     }
 
@@ -271,20 +258,20 @@ public class DropCollectionOperation implements WriteOperation<Void> {
      */
     class ProcessCommandsCallback implements SingleResultCallback<Void> {
         private final AsyncWriteBinding binding;
+        private final AsyncConnectionSource source;
         private final OperationContext operationContext;
-        private final AsyncConnection connection;
         private final SingleResultCallback<Void> finalCallback;
         private final Deque<Supplier<BsonDocument>> commands;
 
         ProcessCommandsCallback(
                 final AsyncWriteBinding binding,
+                final AsyncConnectionSource source,
                 final OperationContext operationContext,
-                final AsyncConnection connection,
                 final List<Supplier<BsonDocument>> commands,
                 final SingleResultCallback<Void> finalCallback) {
             this.binding = binding;
+            this.source = source;
             this.operationContext = operationContext;
-            this.connection = connection;
             this.finalCallback = finalCallback;
             this.commands = new ArrayDeque<>(commands);
         }
@@ -299,12 +286,18 @@ public class DropCollectionOperation implements WriteOperation<Void> {
             if (nextCommandFunction == null) {
                 finalCallback.onResult(null, null);
             } else {
-                try {
-                    executeCommandAsync(binding, operationContext,  namespace.getDatabaseName(), nextCommandFunction.get(),
-                            connection, writeConcernErrorTransformerAsync(operationContext.getTimeoutContext()), this);
-                } catch (MongoOperationTimeoutException operationTimeoutException) {
-                    finalCallback.onResult(null, operationTimeoutException);
-                }
+                RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContext);
+                AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext,
+                        supplierCallback -> {
+                            retryControl.getPolicy().onCommand(DropCollectionOperation.this::getCommandName);
+                            withAsyncConnection(source, operationContext, supplierCallback,
+                                    (connection, connectionScopedOperationContext, connectionReleasingCallback) ->
+                                            executeCommandAsync(binding, connectionScopedOperationContext, namespace.getDatabaseName(),
+                                                    nextCommandFunction.get(), connection,
+                                                    writeConcernErrorTransformerAsync(connectionScopedOperationContext.getTimeoutContext()),
+                                                    connectionReleasingCallback));
+                        });
+                retryingCommandExecutor.get(this);
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
@@ -22,7 +22,6 @@ import com.mongodb.WriteConcern;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.function.AsyncCallbackSupplier;
 import com.mongodb.internal.async.function.RetryControl;
-import com.mongodb.internal.binding.AsyncConnectionSource;
 import com.mongodb.internal.binding.AsyncReadWriteBinding;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.ReadWriteBinding;
@@ -43,8 +42,8 @@ import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWithRetriesAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync;
+import static com.mongodb.internal.operation.AsyncOperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncConnection;
-import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncWriteConnectionSource;
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
 import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceError;
@@ -53,7 +52,6 @@ import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
-import static com.mongodb.internal.operation.SyncOperationHelper.withWriteConnectionSource;
 import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErrorTransformer;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static java.util.Arrays.asList;
@@ -119,13 +117,7 @@ public class DropCollectionOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         BsonDocument localEncryptedFields = getEncryptedFields((ReadWriteBinding) binding, operationContext);
-        List<Supplier<BsonDocument>> commandFunctions = getCommands(localEncryptedFields);
-        // A single (non-Queryable-Encryption) drop re-selects a write source per retry attempt, so overload retries
-        // retarget away from a failed or stepped-down server. The Queryable-Encryption sequence pins one source so the
-        // sub-commands run against a single server; if that server steps down the sequence fails loudly rather than
-        // silently leaving a state collection on a new primary that never replicated its drop.
-        if (commandFunctions.size() == 1) {
-            Supplier<BsonDocument> commandCreator = commandFunctions.get(0);
+        getCommands(localEncryptedFields).forEach(commandCreator -> {
             RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContext);
             Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
                 retryControl.getPolicy().onCommand(this::getCommandName);
@@ -139,27 +131,9 @@ public class DropCollectionOperation implements WriteOperation<Void> {
                     return null;
                 });
             });
-            return retryingCommandExecutor.get();
-        }
-        return withWriteConnectionSource(binding, operationContext, (source, operationContextWithMinRtt) -> {
-            commandFunctions.forEach(commandCreator -> {
-                RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContextWithMinRtt);
-                Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContextWithMinRtt, () -> {
-                    retryControl.getPolicy().onCommand(this::getCommandName);
-                    return withConnection(source, operationContextWithMinRtt, (connection, connectionScopedOperationContext) -> {
-                        try {
-                            executeCommand(binding, connectionScopedOperationContext, namespace.getDatabaseName(), commandCreator.get(),
-                                    connection, writeConcernErrorTransformer(connectionScopedOperationContext.getTimeoutContext()));
-                        } catch (MongoCommandException e) {
-                            rethrowIfNotNamespaceError(e);
-                        }
-                        return null;
-                    });
-                });
-                retryingCommandExecutor.get();
-            });
-            return null;
+            retryingCommandExecutor.get();
         });
+        return null;
     }
 
     @Override
@@ -170,31 +144,7 @@ public class DropCollectionOperation implements WriteOperation<Void> {
                 errorHandlingCallback(callback, LOGGER).onResult(null, t);
                 return;
             }
-            List<Supplier<BsonDocument>> commandFunctions = getCommands(localEncryptedFields);
-            if (commandFunctions.size() == 1) {
-                Supplier<BsonDocument> commandCreator = commandFunctions.get(0);
-                RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContext);
-                AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext,
-                        supplierCallback -> {
-                            retryControl.getPolicy().onCommand(this::getCommandName);
-                            executeCommandAsync(binding, operationContext, namespace.getDatabaseName(),
-                                    (operationContext1, serverDescription, connectionDescription) -> commandCreator.get(),
-                                    writeConcernErrorTransformerAsync(operationContext.getTimeoutContext()),
-                                    (result, t1) -> {
-                                        if (t1 != null && isNamespaceError(t1)) {
-                                            supplierCallback.onResult(null, null);
-                                        } else {
-                                            supplierCallback.onResult(result, t1);
-                                        }
-                                    });
-                        });
-                retryingCommandExecutor.get(callback);
-            } else {
-                withAsyncWriteConnectionSource(binding, operationContext, callback,
-                        (source, operationContextWithMinRtt, sourceReleasingCallback) ->
-                                new ProcessCommandsCallback(binding, source, operationContextWithMinRtt,
-                                        commandFunctions, sourceReleasingCallback).onResult(null, null));
-            }
+            new ProcessCommandsCallback(binding, operationContext, getCommands(localEncryptedFields), callback).onResult(null, null);
         });
     }
 
@@ -301,19 +251,16 @@ public class DropCollectionOperation implements WriteOperation<Void> {
      */
     class ProcessCommandsCallback implements SingleResultCallback<Void> {
         private final AsyncWriteBinding binding;
-        private final AsyncConnectionSource source;
         private final OperationContext operationContext;
         private final SingleResultCallback<Void> finalCallback;
         private final Deque<Supplier<BsonDocument>> commands;
 
         ProcessCommandsCallback(
                 final AsyncWriteBinding binding,
-                final AsyncConnectionSource source,
                 final OperationContext operationContext,
                 final List<Supplier<BsonDocument>> commands,
                 final SingleResultCallback<Void> finalCallback) {
             this.binding = binding;
-            this.source = source;
             this.operationContext = operationContext;
             this.finalCallback = finalCallback;
             this.commands = new ArrayDeque<>(commands);
@@ -333,12 +280,17 @@ public class DropCollectionOperation implements WriteOperation<Void> {
                 AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext,
                         supplierCallback -> {
                             retryControl.getPolicy().onCommand(DropCollectionOperation.this::getCommandName);
-                            withAsyncConnection(source, operationContext, supplierCallback,
-                                    (connection, connectionScopedOperationContext, connectionReleasingCallback) ->
-                                            executeCommandAsync(binding, connectionScopedOperationContext, namespace.getDatabaseName(),
-                                                    nextCommandFunction.get(), connection,
-                                                    writeConcernErrorTransformerAsync(connectionScopedOperationContext.getTimeoutContext()),
-                                                    connectionReleasingCallback));
+                            withAsyncConnection(binding, operationContext, (connection, connectionScopedOperationContext, t1) -> {
+                                if (t1 != null) {
+                                    supplierCallback.onResult(null, t1);
+                                } else {
+                                    SingleResultCallback<Void> connectionReleasingCallback = releasingCallback(supplierCallback, connection);
+                                    executeCommandAsync(binding, connectionScopedOperationContext, namespace.getDatabaseName(),
+                                            nextCommandFunction.get(), connection,
+                                            writeConcernErrorTransformerAsync(connectionScopedOperationContext.getTimeoutContext()),
+                                            connectionReleasingCallback);
+                                }
+                            });
                         });
                 retryingCommandExecutor.get(this);
             }

--- a/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
@@ -142,29 +142,30 @@ public class DropCollectionOperation implements WriteOperation<Void> {
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext,
                              final SingleResultCallback<Void> callback) {
-        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                createSpecRetryPolicy(),
-                operationContext);
-        AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback -> {
-            SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(supplierCallback, LOGGER);
-            getEncryptedFields((AsyncReadWriteBinding) binding, operationContext, (result, t) -> {
-                if (t != null) {
-                    errHandlingCallback.onResult(null, t);
-                } else {
-                    withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t1) -> {
-                        if (t1 != null) {
-                            errHandlingCallback.onResult(null, t1);
-                        } else {
-                            new ProcessCommandsCallback(binding, operationContextWithMinRtt, connection, getCommands(result),
-                                    releasingCallback(errHandlingCallback,
-                                    connection))
-                                    .onResult(null, null);
-                        }
+        getEncryptedFields((AsyncReadWriteBinding) binding, operationContext, (localEncryptedFields, t) -> {
+            if (t != null) {
+                errorHandlingCallback(callback, LOGGER).onResult(null, t);
+                return;
+            }
+            RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                    createSpecRetryPolicy(),
+                    operationContext);
+            AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext,
+                    supplierCallback -> {
+                        SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(supplierCallback, LOGGER);
+                        withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t1) -> {
+                            if (t1 != null) {
+                                errHandlingCallback.onResult(null, t1);
+                            } else {
+                                new ProcessCommandsCallback(binding, operationContextWithMinRtt, connection,
+                                        getCommands(localEncryptedFields),
+                                        releasingCallback(errHandlingCallback, connection))
+                                        .onResult(null, null);
+                            }
+                        });
                     });
-                }
-            });
+            retryingCommandExecutor.get(callback);
         });
-        retryingCommandExecutor.get(callback);
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
@@ -119,8 +119,30 @@ public class DropCollectionOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         BsonDocument localEncryptedFields = getEncryptedFields((ReadWriteBinding) binding, operationContext);
+        List<Supplier<BsonDocument>> commandFunctions = getCommands(localEncryptedFields);
+        // A single (non-Queryable-Encryption) drop re-selects a write source per retry attempt, so overload retries
+        // retarget away from a failed or stepped-down server. The Queryable-Encryption sequence pins one source so the
+        // sub-commands run against a single server; if that server steps down the sequence fails loudly rather than
+        // silently leaving a state collection on a new primary that never replicated its drop.
+        if (commandFunctions.size() == 1) {
+            Supplier<BsonDocument> commandCreator = commandFunctions.get(0);
+            RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContext);
+            Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
+                retryControl.getPolicy().onCommand(this::getCommandName);
+                return withConnection(binding, operationContext, (connection, connectionScopedOperationContext) -> {
+                    try {
+                        executeCommand(binding, connectionScopedOperationContext, namespace.getDatabaseName(), commandCreator.get(),
+                                connection, writeConcernErrorTransformer(connectionScopedOperationContext.getTimeoutContext()));
+                    } catch (MongoCommandException e) {
+                        rethrowIfNotNamespaceError(e);
+                    }
+                    return null;
+                });
+            });
+            return retryingCommandExecutor.get();
+        }
         return withWriteConnectionSource(binding, operationContext, (source, operationContextWithMinRtt) -> {
-            getCommands(localEncryptedFields).forEach(commandCreator -> {
+            commandFunctions.forEach(commandCreator -> {
                 RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContextWithMinRtt);
                 Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContextWithMinRtt, () -> {
                     retryControl.getPolicy().onCommand(this::getCommandName);
@@ -148,10 +170,31 @@ public class DropCollectionOperation implements WriteOperation<Void> {
                 errorHandlingCallback(callback, LOGGER).onResult(null, t);
                 return;
             }
-            withAsyncWriteConnectionSource(binding, operationContext, callback,
-                    (source, operationContextWithMinRtt, sourceReleasingCallback) ->
-                            new ProcessCommandsCallback(binding, source, operationContextWithMinRtt,
-                                    getCommands(localEncryptedFields), sourceReleasingCallback).onResult(null, null));
+            List<Supplier<BsonDocument>> commandFunctions = getCommands(localEncryptedFields);
+            if (commandFunctions.size() == 1) {
+                Supplier<BsonDocument> commandCreator = commandFunctions.get(0);
+                RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(createSpecRetryPolicy(), operationContext);
+                AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext,
+                        supplierCallback -> {
+                            retryControl.getPolicy().onCommand(this::getCommandName);
+                            executeCommandAsync(binding, operationContext, namespace.getDatabaseName(),
+                                    (operationContext1, serverDescription, connectionDescription) -> commandCreator.get(),
+                                    writeConcernErrorTransformerAsync(operationContext.getTimeoutContext()),
+                                    (result, t1) -> {
+                                        if (t1 != null && isNamespaceError(t1)) {
+                                            supplierCallback.onResult(null, null);
+                                        } else {
+                                            supplierCallback.onResult(result, t1);
+                                        }
+                                    });
+                        });
+                retryingCommandExecutor.get(callback);
+            } else {
+                withAsyncWriteConnectionSource(binding, operationContext, callback,
+                        (source, operationContextWithMinRtt, sourceReleasingCallback) ->
+                                new ProcessCommandsCallback(binding, source, operationContextWithMinRtt,
+                                        commandFunctions, sourceReleasingCallback).onResult(null, null));
+            }
         });
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/DropDatabaseOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropDatabaseOperation.java
@@ -40,6 +40,7 @@ import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncConne
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
 import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
+import static com.mongodb.internal.operation.SpecRetryPolicy.IndividualPolicies.overloadForWrite;
 import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
@@ -88,7 +89,7 @@ public class DropDatabaseOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                createSpecRetryPolicy(),
+                overloadForWrite(retryWrites, maxAdaptiveRetriesSetting),
                 operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -104,7 +105,7 @@ public class DropDatabaseOperation implements WriteOperation<Void> {
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                createSpecRetryPolicy(),
+                overloadForWrite(retryWrites, maxAdaptiveRetriesSetting),
                 operationContext);
         AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback ->
                 withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
@@ -126,8 +127,4 @@ public class DropDatabaseOperation implements WriteOperation<Void> {
         return commandDocument;
     }
 
-    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
-        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
-    }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/DropDatabaseOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropDatabaseOperation.java
@@ -92,8 +92,7 @@ public class DropDatabaseOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -109,8 +108,7 @@ public class DropDatabaseOperation implements WriteOperation<Void> {
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 operationContext);
         AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback ->
                 withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
@@ -130,5 +128,10 @@ public class DropDatabaseOperation implements WriteOperation<Void> {
         BsonDocument commandDocument = new BsonDocument("dropDatabase", new BsonInt32(1));
         appendWriteConcernToCommand(writeConcern, commandDocument);
         return commandDocument;
+    }
+
+    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
+        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/DropDatabaseOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropDatabaseOperation.java
@@ -63,10 +63,6 @@ public class DropDatabaseOperation implements WriteOperation<Void> {
         this(databaseName, writeConcern, false, null);
     }
 
-    /**
-     * @param retryWrites Whether overload retries are enabled for this operation.
-     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
-     */
     public DropDatabaseOperation(final String databaseName, @Nullable final WriteConcern writeConcern,
             final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.databaseName = notNull("databaseName", databaseName);

--- a/driver-core/src/main/com/mongodb/internal/operation/DropDatabaseOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropDatabaseOperation.java
@@ -20,6 +20,8 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.internal.MongoNamespaceHelper;
 import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
+import com.mongodb.internal.async.function.RetryControl;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
 import com.mongodb.internal.connection.OperationContext;
@@ -27,13 +29,18 @@ import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 
+import java.util.function.Supplier;
+
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
+import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWithRetriesAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncConnection;
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
+import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
 import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErrorTransformer;
@@ -48,10 +55,24 @@ import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConce
 public class DropDatabaseOperation implements WriteOperation<Void> {
     private final String databaseName;
     private final WriteConcern writeConcern;
+    private final boolean retryWrites;
+    @Nullable
+    private final Integer maxAdaptiveRetriesSetting;
 
     public DropDatabaseOperation(final String databaseName, @Nullable final WriteConcern writeConcern) {
+        this(databaseName, writeConcern, false, null);
+    }
+
+    /**
+     * @param retryWrites Whether overload retries are enabled for this operation.
+     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
+     */
+    public DropDatabaseOperation(final String databaseName, @Nullable final WriteConcern writeConcern,
+            final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.databaseName = notNull("databaseName", databaseName);
         this.writeConcern = writeConcern;
+        this.retryWrites = retryWrites;
+        this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
     }
 
     public WriteConcern getWriteConcern() {
@@ -70,26 +91,39 @@ public class DropDatabaseOperation implements WriteOperation<Void> {
 
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
-        return withConnection(binding, operationContext, (connection, operationContextWithMinRtt) -> {
-            executeCommand(binding, operationContextWithMinRtt,  databaseName, getCommand(), connection, writeConcernErrorTransformer(operationContextWithMinRtt
-                    .getTimeoutContext()));
-            return null;
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
+            retryControl.getPolicy().onCommand(this::getCommandName);
+            return withConnection(binding, operationContext, (connection, operationContextWithMinRtt) -> {
+                executeCommand(binding, operationContextWithMinRtt, databaseName, getCommand(), connection,
+                        writeConcernErrorTransformer(operationContextWithMinRtt.getTimeoutContext()));
+                return null;
+            });
         });
+        return retryingCommandExecutor.get();
     }
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
-        withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
-            SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
-            if (t != null) {
-                errHandlingCallback.onResult(null, t);
-            } else {
-                executeCommandAsync(binding, operationContextWithMinRtt,  databaseName, getCommand(), connection,
-                        writeConcernErrorTransformerAsync(operationContextWithMinRtt.getTimeoutContext()),
-                        releasingCallback(errHandlingCallback, connection));
-
-            }
-        });
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback ->
+                withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
+                    SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(supplierCallback, LOGGER);
+                    if (t != null) {
+                        errHandlingCallback.onResult(null, t);
+                    } else {
+                        executeCommandAsync(binding, operationContextWithMinRtt, databaseName, getCommand(), connection,
+                                writeConcernErrorTransformerAsync(operationContextWithMinRtt.getTimeoutContext()),
+                                releasingCallback(errHandlingCallback, connection));
+                    }
+                }));
+        retryingCommandExecutor.get(callback);
     }
 
     private BsonDocument getCommand() {

--- a/driver-core/src/main/com/mongodb/internal/operation/DropIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropIndexOperation.java
@@ -66,10 +66,6 @@ public class DropIndexOperation implements WriteOperation<Void> {
         this(namespace, indexKeys, writeConcern, false, null);
     }
 
-    /**
-     * @param retryWrites Whether overload retries are enabled for this operation.
-     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
-     */
     public DropIndexOperation(final MongoNamespace namespace, final String indexName, @Nullable final WriteConcern writeConcern,
                               final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.namespace = notNull("namespace", namespace);
@@ -80,10 +76,6 @@ public class DropIndexOperation implements WriteOperation<Void> {
         this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
     }
 
-    /**
-     * @param retryWrites Whether overload retries are enabled for this operation.
-     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
-     */
     public DropIndexOperation(final MongoNamespace namespace, final BsonDocument indexKeys, @Nullable final WriteConcern writeConcern,
                               final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.namespace = notNull("namespace", namespace);

--- a/driver-core/src/main/com/mongodb/internal/operation/DropIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropIndexOperation.java
@@ -38,6 +38,7 @@ import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernEr
 import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceError;
 import static com.mongodb.internal.operation.CommandOperationHelper.rethrowIfNotNamespaceError;
+import static com.mongodb.internal.operation.SpecRetryPolicy.IndividualPolicies.overloadForWrite;
 import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErrorTransformer;
@@ -103,7 +104,7 @@ public class DropIndexOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                createSpecRetryPolicy(),
+                overloadForWrite(retryWrites, maxAdaptiveRetriesSetting),
                 operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -123,7 +124,7 @@ public class DropIndexOperation implements WriteOperation<Void> {
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext,
                              final SingleResultCallback<Void> callback) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                createSpecRetryPolicy(),
+                overloadForWrite(retryWrites, maxAdaptiveRetriesSetting),
                 operationContext);
         AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -152,8 +153,4 @@ public class DropIndexOperation implements WriteOperation<Void> {
         };
     }
 
-    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
-        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
-    }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/DropIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropIndexOperation.java
@@ -111,8 +111,7 @@ public class DropIndexOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -132,8 +131,7 @@ public class DropIndexOperation implements WriteOperation<Void> {
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext,
                              final SingleResultCallback<Void> callback) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 operationContext);
         AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -160,5 +158,10 @@ public class DropIndexOperation implements WriteOperation<Void> {
             appendWriteConcernToCommand(writeConcern, command);
             return command;
         };
+    }
+
+    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
+        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/DropIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropIndexOperation.java
@@ -20,6 +20,8 @@ import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
+import com.mongodb.internal.async.function.RetryControl;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
 import com.mongodb.internal.connection.OperationContext;
@@ -27,11 +29,16 @@ import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 
+import java.util.function.Supplier;
+
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWithRetriesAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceError;
 import static com.mongodb.internal.operation.CommandOperationHelper.rethrowIfNotNamespaceError;
+import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErrorTransformer;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
@@ -47,19 +54,44 @@ public class DropIndexOperation implements WriteOperation<Void> {
     private final String indexName;
     private final BsonDocument indexKeys;
     private final WriteConcern writeConcern;
+    private final boolean retryWrites;
+    @Nullable
+    private final Integer maxAdaptiveRetriesSetting;
 
     public DropIndexOperation(final MongoNamespace namespace, final String indexName, @Nullable final WriteConcern writeConcern) {
+        this(namespace, indexName, writeConcern, false, null);
+    }
+
+    public DropIndexOperation(final MongoNamespace namespace, final BsonDocument indexKeys, @Nullable final WriteConcern writeConcern) {
+        this(namespace, indexKeys, writeConcern, false, null);
+    }
+
+    /**
+     * @param retryWrites Whether overload retries are enabled for this operation.
+     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
+     */
+    public DropIndexOperation(final MongoNamespace namespace, final String indexName, @Nullable final WriteConcern writeConcern,
+                              final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.namespace = notNull("namespace", namespace);
         this.indexName = notNull("indexName", indexName);
         this.indexKeys = null;
         this.writeConcern = writeConcern;
+        this.retryWrites = retryWrites;
+        this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
     }
 
-    public DropIndexOperation(final MongoNamespace namespace, final BsonDocument indexKeys, @Nullable final WriteConcern writeConcern) {
+    /**
+     * @param retryWrites Whether overload retries are enabled for this operation.
+     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
+     */
+    public DropIndexOperation(final MongoNamespace namespace, final BsonDocument indexKeys, @Nullable final WriteConcern writeConcern,
+                              final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.namespace = notNull("namespace", namespace);
         this.indexKeys = notNull("indexKeys", indexKeys);
         this.indexName = null;
         this.writeConcern = writeConcern;
+        this.retryWrites = retryWrites;
+        this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
     }
 
     public WriteConcern getWriteConcern() {
@@ -78,9 +110,18 @@ public class DropIndexOperation implements WriteOperation<Void> {
 
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
-        try {
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
+            retryControl.getPolicy().onCommand(this::getCommandName);
             executeCommand(binding, operationContext, namespace.getDatabaseName(), getCommandCreator(), writeConcernErrorTransformer(
                     operationContext.getTimeoutContext()));
+            return null;
+        });
+        try {
+            retryingCommandExecutor.get();
         } catch (MongoCommandException e) {
             rethrowIfNotNamespaceError(e);
         }
@@ -90,8 +131,16 @@ public class DropIndexOperation implements WriteOperation<Void> {
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext,
                              final SingleResultCallback<Void> callback) {
-        executeCommandAsync(binding, operationContext,  namespace.getDatabaseName(), getCommandCreator(),
-                writeConcernErrorTransformerAsync(operationContext.getTimeoutContext()), (result, t) -> {
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback -> {
+            retryControl.getPolicy().onCommand(this::getCommandName);
+            executeCommandAsync(binding, operationContext, namespace.getDatabaseName(), getCommandCreator(),
+                    writeConcernErrorTransformerAsync(operationContext.getTimeoutContext()), supplierCallback);
+        });
+        retryingCommandExecutor.get((result, t) -> {
             if (t != null && !isNamespaceError(t)) {
                 callback.onResult(null, t);
             } else {

--- a/driver-core/src/main/com/mongodb/internal/operation/DropSearchIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropSearchIndexOperation.java
@@ -36,10 +36,6 @@ final class DropSearchIndexOperation extends AbstractWriteSearchIndexOperation {
         this(namespace, indexName, false, null);
     }
 
-    /**
-     * @param retryWrites Whether overload retries are enabled for this operation.
-     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
-     */
     DropSearchIndexOperation(final MongoNamespace namespace, final String indexName,
             final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         super(namespace, retryWrites, maxAdaptiveRetriesSetting);

--- a/driver-core/src/main/com/mongodb/internal/operation/DropSearchIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropSearchIndexOperation.java
@@ -33,7 +33,16 @@ final class DropSearchIndexOperation extends AbstractWriteSearchIndexOperation {
     private final String indexName;
 
     DropSearchIndexOperation(final MongoNamespace namespace, final String indexName) {
-        super(namespace);
+        this(namespace, indexName, false, null);
+    }
+
+    /**
+     * @param retryWrites Whether overload retries are enabled for this operation.
+     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
+     */
+    DropSearchIndexOperation(final MongoNamespace namespace, final String indexName,
+            final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
+        super(namespace, retryWrites, maxAdaptiveRetriesSetting);
         this.indexName = indexName;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -337,7 +337,8 @@ public final class Operations<T> {
             final Boolean allowDiskUse, final Boolean bypassDocumentValidation, final Collation collation, @Nullable final Bson hint,
             @Nullable final String hintString, final BsonValue comment, final Bson variables, final AggregationLevel aggregationLevel) {
         return new AggregateToCollectionOperation(assertNotNull(namespace),
-                assertNotNull(toBsonDocumentList(pipeline)), readConcern, writeConcern, aggregationLevel)
+                assertNotNull(toBsonDocumentList(pipeline)), readConcern, writeConcern, aggregationLevel,
+                isRetryWrites(), maxAdaptiveRetriesSetting)
                 .allowDiskUse(allowDiskUse)
                 .bypassDocumentValidation(bypassDocumentValidation)
                 .collation(collation)
@@ -613,13 +614,13 @@ public final class Operations<T> {
 
     public WriteOperation<Void> dropDatabase() {
         return new DropDatabaseOperation(assertNotNull(namespace).getDatabaseName(),
-                getWriteConcern());
+                getWriteConcern(), isRetryWrites(), maxAdaptiveRetriesSetting);
     }
 
     public WriteOperation<Void> createCollection(final String collectionName, final CreateCollectionOptions createCollectionOptions,
             @Nullable final AutoEncryptionSettings autoEncryptionSettings) {
         CreateCollectionOperation operation = new CreateCollectionOperation(
-                assertNotNull(namespace).getDatabaseName(), collectionName, writeConcern)
+                assertNotNull(namespace).getDatabaseName(), collectionName, writeConcern, isRetryWrites(), maxAdaptiveRetriesSetting)
                 .collation(createCollectionOptions.getCollation())
                 .capped(createCollectionOptions.isCapped())
                 .sizeInBytes(createCollectionOptions.getSizeInBytes())
@@ -662,7 +663,7 @@ public final class Operations<T> {
             final DropCollectionOptions dropCollectionOptions,
             @Nullable final AutoEncryptionSettings autoEncryptionSettings) {
         DropCollectionOperation operation = new DropCollectionOperation(
-                assertNotNull(namespace), writeConcern);
+                assertNotNull(namespace), writeConcern, isRetryWrites(), maxAdaptiveRetriesSetting);
         Bson encryptedFields = dropCollectionOptions.getEncryptedFields();
         if (encryptedFields != null) {
             operation.encryptedFields(assertNotNull(toBsonDocument(encryptedFields)));
@@ -680,7 +681,8 @@ public final class Operations<T> {
     public WriteOperation<Void> renameCollection(final MongoNamespace newCollectionNamespace,
             final RenameCollectionOptions renameCollectionOptions) {
         return new RenameCollectionOperation(assertNotNull(namespace),
-                newCollectionNamespace, writeConcern).dropTarget(renameCollectionOptions.isDropTarget());
+                newCollectionNamespace, writeConcern, isRetryWrites(), maxAdaptiveRetriesSetting)
+                .dropTarget(renameCollectionOptions.isDropTarget());
     }
 
     public WriteOperation<Void> createView(final String viewName, final String viewOn, final List<? extends Bson> pipeline,
@@ -688,7 +690,8 @@ public final class Operations<T> {
         notNull("options", createViewOptions);
         notNull("pipeline", pipeline);
         return new CreateViewOperation(assertNotNull(namespace).getDatabaseName(), viewName,
-                viewOn, assertNotNull(toBsonDocumentList(pipeline)), writeConcern).collation(createViewOptions.getCollation());
+                viewOn, assertNotNull(toBsonDocumentList(pipeline)), writeConcern, isRetryWrites(), maxAdaptiveRetriesSetting)
+                .collation(createViewOptions.getCollation());
     }
 
     public WriteOperation<Void> createIndexes(final List<IndexModel> indexes, final CreateIndexOptions createIndexOptions) {
@@ -722,7 +725,7 @@ public final class Operations<T> {
             );
         }
         return new CreateIndexesOperation(
-                assertNotNull(namespace), indexRequests, writeConcern)
+                assertNotNull(namespace), indexRequests, writeConcern, isRetryWrites(), maxAdaptiveRetriesSetting)
                 .commitQuorum(createIndexOptions.getCommitQuorum());
     }
 
@@ -730,18 +733,18 @@ public final class Operations<T> {
         List<SearchIndexRequest> indexRequests = indexes.stream()
                 .map(this::createSearchIndexRequest)
                 .collect(Collectors.toList());
-        return new CreateSearchIndexesOperation(assertNotNull(namespace), indexRequests);
+        return new CreateSearchIndexesOperation(assertNotNull(namespace), indexRequests, isRetryWrites(), maxAdaptiveRetriesSetting);
     }
 
     public WriteOperation<Void> updateSearchIndex(final String indexName, final Bson definition) {
         BsonDocument definitionDocument = assertNotNull(toBsonDocument(definition));
         SearchIndexRequest searchIndexRequest = new SearchIndexRequest(definitionDocument, indexName);
-        return new UpdateSearchIndexesOperation(assertNotNull(namespace), searchIndexRequest);
+        return new UpdateSearchIndexesOperation(assertNotNull(namespace), searchIndexRequest, isRetryWrites(), maxAdaptiveRetriesSetting);
     }
 
 
     public WriteOperation<Void> dropSearchIndex(final String indexName) {
-        return new DropSearchIndexOperation(assertNotNull(namespace), indexName);
+        return new DropSearchIndexOperation(assertNotNull(namespace), indexName, isRetryWrites(), maxAdaptiveRetriesSetting);
     }
 
 
@@ -753,11 +756,12 @@ public final class Operations<T> {
     }
 
     public WriteOperation<Void> dropIndex(final String indexName, final DropIndexOptions ignoredOptions) {
-        return new DropIndexOperation(assertNotNull(namespace), indexName, writeConcern);
+        return new DropIndexOperation(assertNotNull(namespace), indexName, writeConcern, isRetryWrites(), maxAdaptiveRetriesSetting);
     }
 
     public WriteOperation<Void> dropIndex(final Bson keys, final DropIndexOptions ignoredOptions) {
-        return new DropIndexOperation(assertNotNull(namespace), keys.toBsonDocument(BsonDocument.class, codecRegistry), writeConcern);
+        return new DropIndexOperation(assertNotNull(namespace), keys.toBsonDocument(BsonDocument.class, codecRegistry), writeConcern,
+                isRetryWrites(), maxAdaptiveRetriesSetting);
     }
 
     public <R> ReadOperationCursor<R> listCollections(final String databaseName, final Class<R> resultClass,

--- a/driver-core/src/main/com/mongodb/internal/operation/RenameCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/RenameCollectionOperation.java
@@ -19,6 +19,8 @@ package com.mongodb.internal.operation;
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
+import com.mongodb.internal.async.function.RetryControl;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
 import com.mongodb.internal.connection.OperationContext;
@@ -27,14 +29,19 @@ import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 
+import java.util.function.Supplier;
+
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
+import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWithRetriesAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncConnection;
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
+import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
 import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErrorTransformer;
@@ -53,13 +60,28 @@ public class RenameCollectionOperation implements WriteOperation<Void> {
     private final MongoNamespace originalNamespace;
     private final MongoNamespace newNamespace;
     private final WriteConcern writeConcern;
+    private final boolean retryWrites;
+    @Nullable
+    private final Integer maxAdaptiveRetriesSetting;
     private boolean dropTarget;
 
     public RenameCollectionOperation(final MongoNamespace originalNamespace, final MongoNamespace newNamespace,
             @Nullable final WriteConcern writeConcern) {
+        this(originalNamespace, newNamespace, writeConcern, false, null);
+    }
+
+    /**
+     * @param retryWrites Whether overload retries are enabled for this operation.
+     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
+     */
+    public RenameCollectionOperation(final MongoNamespace originalNamespace, final MongoNamespace newNamespace,
+            @Nullable final WriteConcern writeConcern, final boolean retryWrites,
+            @Nullable final Integer maxAdaptiveRetriesSetting) {
         this.originalNamespace = notNull("originalNamespace", originalNamespace);
         this.newNamespace = notNull("newNamespace", newNamespace);
         this.writeConcern = writeConcern;
+        this.retryWrites = retryWrites;
+        this.maxAdaptiveRetriesSetting = maxAdaptiveRetriesSetting;
     }
 
     public WriteConcern getWriteConcern() {
@@ -87,24 +109,38 @@ public class RenameCollectionOperation implements WriteOperation<Void> {
 
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
-        return withConnection(binding, operationContext, (connection, operationContextWithMinRtt) ->
-                executeCommand(binding,
-                        operationContextWithMinRtt, "admin", getCommand(), connection,
-                        writeConcernErrorTransformer(operationContextWithMinRtt.getTimeoutContext())));
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
+            retryControl.getPolicy().onCommand(this::getCommandName);
+            return withConnection(binding, operationContext, (connection, operationContextWithMinRtt) ->
+                    executeCommand(binding,
+                            operationContextWithMinRtt, "admin", getCommand(), connection,
+                            writeConcernErrorTransformer(operationContextWithMinRtt.getTimeoutContext())));
+        });
+        return retryingCommandExecutor.get();
     }
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
-        withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
-            SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
-            if (t != null) {
-                errHandlingCallback.onResult(null, t);
-            } else {
-                executeCommandAsync(binding, operationContextWithMinRtt, "admin", getCommand(), assertNotNull(connection),
-                        writeConcernErrorTransformerAsync(operationContextWithMinRtt.getTimeoutContext()),
-                        releasingCallback(errHandlingCallback, connection));
-            }
-        });
+        RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
+                new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                operationContext);
+        AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback ->
+                withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
+                    SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(supplierCallback, LOGGER);
+                    if (t != null) {
+                        errHandlingCallback.onResult(null, t);
+                    } else {
+                        executeCommandAsync(binding, operationContextWithMinRtt, "admin", getCommand(), assertNotNull(connection),
+                                writeConcernErrorTransformerAsync(operationContextWithMinRtt.getTimeoutContext()),
+                                releasingCallback(errHandlingCallback, connection));
+                    }
+                }));
+        retryingCommandExecutor.get(callback);
     }
 
     private BsonDocument getCommand() {

--- a/driver-core/src/main/com/mongodb/internal/operation/RenameCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/RenameCollectionOperation.java
@@ -70,10 +70,6 @@ public class RenameCollectionOperation implements WriteOperation<Void> {
         this(originalNamespace, newNamespace, writeConcern, false, null);
     }
 
-    /**
-     * @param retryWrites Whether overload retries are enabled for this operation.
-     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
-     */
     public RenameCollectionOperation(final MongoNamespace originalNamespace, final MongoNamespace newNamespace,
             @Nullable final WriteConcern writeConcern, final boolean retryWrites,
             @Nullable final Integer maxAdaptiveRetriesSetting) {

--- a/driver-core/src/main/com/mongodb/internal/operation/RenameCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/RenameCollectionOperation.java
@@ -110,8 +110,7 @@ public class RenameCollectionOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -126,8 +125,7 @@ public class RenameCollectionOperation implements WriteOperation<Void> {
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                        .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY),
+                createSpecRetryPolicy(),
                 operationContext);
         AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback ->
                 withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
@@ -149,5 +147,10 @@ public class RenameCollectionOperation implements WriteOperation<Void> {
                                             .append("dropTarget", BsonBoolean.valueOf(dropTarget));
         appendWriteConcernToCommand(writeConcern, commandDocument);
         return commandDocument;
+    }
+
+    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
+        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
+                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/RenameCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/RenameCollectionOperation.java
@@ -41,6 +41,7 @@ import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncConne
 import static com.mongodb.internal.operation.AsyncOperationHelper.writeConcernErrorTransformerAsync;
 import static com.mongodb.internal.operation.CommandOperationHelper.createSpecRetryControl;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
+import static com.mongodb.internal.operation.SpecRetryPolicy.IndividualPolicies.overloadForWrite;
 import static com.mongodb.internal.operation.SyncOperationHelper.decorateWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.withConnection;
@@ -106,7 +107,7 @@ public class RenameCollectionOperation implements WriteOperation<Void> {
     @Override
     public Void execute(final WriteBinding binding, final OperationContext operationContext) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                createSpecRetryPolicy(),
+                overloadForWrite(retryWrites, maxAdaptiveRetriesSetting),
                 operationContext);
         Supplier<Void> retryingCommandExecutor = decorateWithRetries(retryControl, operationContext, () -> {
             retryControl.getPolicy().onCommand(this::getCommandName);
@@ -121,7 +122,7 @@ public class RenameCollectionOperation implements WriteOperation<Void> {
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<Void> callback) {
         RetryControl<SpecRetryPolicy> retryControl = createSpecRetryControl(
-                createSpecRetryPolicy(),
+                overloadForWrite(retryWrites, maxAdaptiveRetriesSetting),
                 operationContext);
         AsyncCallbackSupplier<Void> retryingCommandExecutor = decorateWithRetriesAsync(retryControl, operationContext, supplierCallback ->
                 withAsyncConnection(binding, operationContext, (connection, operationContextWithMinRtt, t) -> {
@@ -145,8 +146,4 @@ public class RenameCollectionOperation implements WriteOperation<Void> {
         return commandDocument;
     }
 
-    private SpecRetryPolicy.IndividualPolicies createSpecRetryPolicy() {
-        return new SpecRetryPolicy.IndividualPolicies(retryWrites)
-                .includeOverload(maxAdaptiveRetriesSetting, SpecRetryPolicy.ErrorPropagation.AS_WRITE_POLICY);
-    }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/SpecRetryPolicy.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SpecRetryPolicy.java
@@ -331,6 +331,16 @@ final class SpecRetryPolicy implements RetryPolicy {
             this.policies = new EnumMap<>(Descriptor.class);
         }
 
+        static IndividualPolicies overloadForWrite(final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
+            return new IndividualPolicies(retryWrites)
+                    .includeOverload(maxAdaptiveRetriesSetting, ErrorPropagation.AS_WRITE_POLICY);
+        }
+
+        static IndividualPolicies overloadForRead(final boolean retryReads, @Nullable final Integer maxAdaptiveRetriesSetting) {
+            return new IndividualPolicies(retryReads)
+                    .includeOverload(maxAdaptiveRetriesSetting, ErrorPropagation.AS_READ_POLICY);
+        }
+
         private IndividualPolicies assertValid() {
             assertFalse(policies.isEmpty());
             assertNoConflicts(policies.keySet());
@@ -692,7 +702,7 @@ final class SpecRetryPolicy implements RetryPolicy {
      * Selects the error propagation shape for overload-only policy
      * compositions (see {@link IndividualPolicies#includeOverload(Integer, ErrorPropagation)}).
      */
-    enum ErrorPropagation {
+    private enum ErrorPropagation {
         AS_READ_POLICY,
         AS_WRITE_POLICY
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
@@ -110,19 +110,6 @@ final class SyncOperationHelper {
         }
     }
 
-    static <T> T withWriteConnectionSource(final WriteBinding binding,
-                                           final OperationContext operationContext,
-                                           final CallableWithSource<T> callable) {
-        OperationContext serverSelectionOperationContext =
-                operationContext.withOverride(TimeoutContext::withComputedServerSelectionTimeout);
-        ConnectionSource source = binding.getWriteConnectionSource(serverSelectionOperationContext);
-        try {
-            return callable.call(source, operationContext.withMinRoundTripTime(source.getServerDescription()));
-        } finally {
-            source.release();
-        }
-    }
-
     static <T> T withConnection(final WriteBinding binding,
                                 final OperationContext operationContext,
                                 final CallableWithConnection<T> callable) {

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
@@ -135,21 +135,6 @@ final class SyncOperationHelper {
     }
 
     /**
-     * Gets a {@link Connection} from the already selected {@code source} and executes the {@code callable} with it.
-     * Guarantees to {@linkplain ReferenceCounted#release() release} the connection after completion of the {@code callable},
-     * while leaving the {@code source} intact, so that the caller may check out further connections from the same server.
-     */
-    static <T> T withConnection(final ConnectionSource source,
-                                final OperationContext operationContext,
-                                final CallableWithConnection<T> callable) {
-        return withSuppliedResource(
-                source::getConnection,
-                false,
-                operationContext,
-                connection -> callable.call(connection, operationContext));
-    }
-
-    /**
      * Gets a {@link ConnectionSource} and a {@link Connection} from the {@code sourceSupplier} and executes the {@code function} with them.
      * Guarantees to {@linkplain ReferenceCounted#release() release} the source and the connection after completion of the {@code function}.
      */

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
@@ -110,6 +110,19 @@ final class SyncOperationHelper {
         }
     }
 
+    static <T> T withWriteConnectionSource(final WriteBinding binding,
+                                           final OperationContext operationContext,
+                                           final CallableWithSource<T> callable) {
+        OperationContext serverSelectionOperationContext =
+                operationContext.withOverride(TimeoutContext::withComputedServerSelectionTimeout);
+        ConnectionSource source = binding.getWriteConnectionSource(serverSelectionOperationContext);
+        try {
+            return callable.call(source, operationContext.withMinRoundTripTime(source.getServerDescription()));
+        } finally {
+            source.release();
+        }
+    }
+
     static <T> T withConnection(final WriteBinding binding,
                                 final OperationContext operationContext,
                                 final CallableWithConnection<T> callable) {
@@ -119,6 +132,21 @@ final class SyncOperationHelper {
                 operationContext,
                 (source, connection, operationContextWithMinRtt) ->
                         callable.call(connection, operationContextWithMinRtt));
+    }
+
+    /**
+     * Gets a {@link Connection} from the already selected {@code source} and executes the {@code callable} with it.
+     * Guarantees to {@linkplain ReferenceCounted#release() release} the connection after completion of the {@code callable},
+     * while leaving the {@code source} intact, so that the caller may check out further connections from the same server.
+     */
+    static <T> T withConnection(final ConnectionSource source,
+                                final OperationContext operationContext,
+                                final CallableWithConnection<T> callable) {
+        return withSuppliedResource(
+                source::getConnection,
+                false,
+                operationContext,
+                connection -> callable.call(connection, operationContext));
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/operation/UpdateSearchIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/UpdateSearchIndexesOperation.java
@@ -17,6 +17,7 @@
 package com.mongodb.internal.operation;
 
 import com.mongodb.MongoNamespace;
+import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 
@@ -30,7 +31,16 @@ final class UpdateSearchIndexesOperation extends AbstractWriteSearchIndexOperati
     private final SearchIndexRequest request;
 
     UpdateSearchIndexesOperation(final MongoNamespace namespace, final SearchIndexRequest request) {
-        super(namespace);
+        this(namespace, request, false, null);
+    }
+
+    /**
+     * @param retryWrites Whether overload retries are enabled for this operation.
+     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
+     */
+    UpdateSearchIndexesOperation(final MongoNamespace namespace, final SearchIndexRequest request,
+            final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
+        super(namespace, retryWrites, maxAdaptiveRetriesSetting);
         this.request = request;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/UpdateSearchIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/UpdateSearchIndexesOperation.java
@@ -34,10 +34,6 @@ final class UpdateSearchIndexesOperation extends AbstractWriteSearchIndexOperati
         this(namespace, request, false, null);
     }
 
-    /**
-     * @param retryWrites Whether overload retries are enabled for this operation.
-     * @param maxAdaptiveRetriesSetting The maximum number of overload retries, or {@code null} to use the default.
-     */
     UpdateSearchIndexesOperation(final MongoNamespace namespace, final SearchIndexRequest request,
             final boolean retryWrites, @Nullable final Integer maxAdaptiveRetriesSetting) {
         super(namespace, retryWrites, maxAdaptiveRetriesSetting);

--- a/driver-legacy/src/main/com/mongodb/DB.java
+++ b/driver-legacy/src/main/com/mongodb/DB.java
@@ -195,7 +195,8 @@ public class DB {
      */
     public void dropDatabase() {
         try {
-            getExecutor().execute(new DropDatabaseOperation(getName(), getWriteConcern()), getReadConcern());
+            getExecutor().execute(new DropDatabaseOperation(getName(), getWriteConcern(),
+                    mongo.getMongoClientOptions().getRetryWrites(), mongo.getMongoClientOptions().getMaxAdaptiveRetries()), getReadConcern());
         } catch (MongoWriteConcernException e) {
             throw createWriteConcernException(e);
         }
@@ -310,7 +311,8 @@ public class DB {
             notNull("options", options);
             DBCollection view = getCollection(viewName);
             executor.execute(new CreateViewOperation(name, viewName, viewOn,
-                    view.preparePipeline(pipeline), writeConcern)
+                    view.preparePipeline(pipeline), writeConcern,
+                    mongo.getMongoClientOptions().getRetryWrites(), mongo.getMongoClientOptions().getMaxAdaptiveRetries())
                     .collation(options.getCollation()), getReadConcern());
             return view;
         } catch (MongoWriteConcernException e) {
@@ -387,7 +389,7 @@ public class DB {
         }
         Collation collation = DBObjectCollationHelper.createCollationFromOptions(options);
         return new CreateCollectionOperation(getName(), collectionName,
-                getWriteConcern())
+                getWriteConcern(), mongo.getMongoClientOptions().getRetryWrites(), mongo.getMongoClientOptions().getMaxAdaptiveRetries())
                    .capped(capped)
                    .collation(collation)
                    .sizeInBytes(sizeInBytes)

--- a/driver-legacy/src/main/com/mongodb/DBCollection.java
+++ b/driver-legacy/src/main/com/mongodb/DBCollection.java
@@ -32,6 +32,7 @@ import com.mongodb.internal.bulk.IndexRequest;
 import com.mongodb.internal.bulk.InsertRequest;
 import com.mongodb.internal.bulk.UpdateRequest;
 import com.mongodb.internal.bulk.WriteRequest.Type;
+import com.mongodb.internal.client.model.AggregationLevel;
 import com.mongodb.internal.connection.PowerOfTwoBufferPool;
 import com.mongodb.internal.operation.AggregateOperation;
 import com.mongodb.internal.operation.AggregateToCollectionOperation;
@@ -1250,7 +1251,8 @@ public class DBCollection {
         if (outCollection != null) {
             AggregateToCollectionOperation operation =
                     new AggregateToCollectionOperation(
-                            getNamespace(), stages, getReadConcern(), getWriteConcern())
+                            getNamespace(), stages, getReadConcern(), getWriteConcern(), AggregationLevel.COLLECTION,
+                            retryWrites, maxAdaptiveRetriesSetting)
                             .allowDiskUse(options.getAllowDiskUse())
                             .bypassDocumentValidation(options.getBypassDocumentValidation())
                             .collation(options.getCollation());

--- a/driver-legacy/src/main/com/mongodb/DBCollection.java
+++ b/driver-legacy/src/main/com/mongodb/DBCollection.java
@@ -979,7 +979,8 @@ public class DBCollection {
     public DBCollection rename(final String newName, final boolean dropTarget) {
         try {
             executor.execute(new RenameCollectionOperation(getNamespace(),
-                    new MongoNamespace(getNamespace().getDatabaseName(), newName), getWriteConcern())
+                    new MongoNamespace(getNamespace().getDatabaseName(), newName), getWriteConcern(),
+                    retryWrites, maxAdaptiveRetriesSetting)
                     .dropTarget(dropTarget), getReadConcern());
             return getDB().getCollection(newName);
         } catch (MongoWriteConcernException e) {
@@ -1818,7 +1819,7 @@ public class DBCollection {
     public void drop() {
         try {
             executor.execute(new DropCollectionOperation(getNamespace(),
-                            getWriteConcern()), getReadConcern());
+                            getWriteConcern(), retryWrites, maxAdaptiveRetriesSetting), getReadConcern());
         } catch (MongoWriteConcernException e) {
             throw createWriteConcernException(e);
         }
@@ -1913,7 +1914,7 @@ public class DBCollection {
     public void dropIndex(final DBObject index) {
         try {
             executor.execute(new DropIndexOperation(getNamespace(), wrap(index),
-                    getWriteConcern()), getReadConcern());
+                    getWriteConcern(), retryWrites, maxAdaptiveRetriesSetting), getReadConcern());
         } catch (MongoWriteConcernException e) {
             throw createWriteConcernException(e);
         }
@@ -1929,7 +1930,7 @@ public class DBCollection {
     public void dropIndex(final String indexName) {
         try {
             executor.execute(new DropIndexOperation(getNamespace(), indexName,
-                    getWriteConcern()), getReadConcern());
+                    getWriteConcern(), retryWrites, maxAdaptiveRetriesSetting), getReadConcern());
         } catch (MongoWriteConcernException e) {
             throw createWriteConcernException(e);
         }
@@ -2156,7 +2157,7 @@ public class DBCollection {
         if (options.containsField("collation")) {
             request.collation(DBObjectCollationHelper.createCollationFromOptions(options));
         }
-        return new CreateIndexesOperation(getNamespace(), singletonList(request), writeConcern);
+        return new CreateIndexesOperation(getNamespace(), singletonList(request), writeConcern, retryWrites, maxAdaptiveRetriesSetting);
     }
 
     Codec<DBObject> getObjectCodec() {

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionSpecification.groovy
@@ -676,7 +676,8 @@ class DBCollectionSpecification extends Specification {
 
         then:
         expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
-                bsonPipeline, collection.getReadConcern(), collection.getWriteConcern(), AggregationLevel.COLLECTION, true, null).collation(collation))
+                bsonPipeline, collection.getReadConcern(), collection.getWriteConcern(),
+                AggregationLevel.COLLECTION, true, null).collation(collation))
     }
 
     def 'explainAggregate should create the correct AggregateOperation'() {

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionSpecification.groovy
@@ -32,6 +32,7 @@ import com.mongodb.internal.bulk.DeleteRequest
 import com.mongodb.internal.bulk.IndexRequest
 import com.mongodb.internal.bulk.InsertRequest
 import com.mongodb.internal.bulk.UpdateRequest
+import com.mongodb.internal.client.model.AggregationLevel
 import com.mongodb.internal.operation.AggregateOperation
 import com.mongodb.internal.operation.AggregateToCollectionOperation
 import com.mongodb.internal.operation.BatchCursor
@@ -661,21 +662,21 @@ class DBCollectionSpecification extends Specification {
 
         then:
         expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
-                bsonPipeline, collection.getReadConcern(), collection.getWriteConcern()))
+                bsonPipeline, collection.getReadConcern(), collection.getWriteConcern(), AggregationLevel.COLLECTION, true, null))
 
         when: // Inherits from DB
         collection.aggregate(pipeline, AggregationOptions.builder().build())
 
         then:
         expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
-                bsonPipeline, collection.getReadConcern(), collection.getWriteConcern()))
+                bsonPipeline, collection.getReadConcern(), collection.getWriteConcern(), AggregationLevel.COLLECTION, true, null))
 
         when:
         collection.aggregate(pipeline, AggregationOptions.builder().collation(collation).build())
 
         then:
         expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
-                bsonPipeline, collection.getReadConcern(), collection.getWriteConcern()).collation(collation))
+                bsonPipeline, collection.getReadConcern(), collection.getWriteConcern(), AggregationLevel.COLLECTION, true, null).collation(collation))
     }
 
     def 'explainAggregate should create the correct AggregateOperation'() {

--- a/driver-legacy/src/test/unit/com/mongodb/DBSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/DBSpecification.groovy
@@ -88,7 +88,7 @@ class DBSpecification extends Specification {
 
         then:
         def operation = executor.getWriteOperation() as CreateCollectionOperation
-        expect operation, isTheSameAs(new CreateCollectionOperation('test', 'ctest', db.getWriteConcern()))
+        expect operation, isTheSameAs(new CreateCollectionOperation('test', 'ctest', db.getWriteConcern(), true, null))
         executor.getReadConcern() == ReadConcern.MAJORITY
 
         when:
@@ -108,7 +108,7 @@ class DBSpecification extends Specification {
         operation = executor.getWriteOperation() as CreateCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new CreateCollectionOperation('test', 'ctest', db.getWriteConcern())
+        expect operation, isTheSameAs(new CreateCollectionOperation('test', 'ctest', db.getWriteConcern(), true, null)
                 .sizeInBytes(100000)
                 .maxDocuments(2000)
                 .capped(true)
@@ -136,7 +136,7 @@ class DBSpecification extends Specification {
         operation = executor.getWriteOperation() as CreateCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new CreateCollectionOperation('test', 'ctest', db.getWriteConcern())
+        expect operation, isTheSameAs(new CreateCollectionOperation('test', 'ctest', db.getWriteConcern(), true, null)
                 .collation(collation))
         executor.getReadConcern() == ReadConcern.MAJORITY
     }
@@ -167,7 +167,7 @@ class DBSpecification extends Specification {
         then:
         def operation = executor.getWriteOperation() as CreateViewOperation
         expect operation, isTheSameAs(new CreateViewOperation(databaseName, viewName, viewOn,
-                [new BsonDocument('$match', new BsonDocument('x', BsonBoolean.TRUE))], writeConcern))
+                [new BsonDocument('$match', new BsonDocument('x', BsonBoolean.TRUE))], writeConcern, true, null))
         executor.getReadConcern() == ReadConcern.MAJORITY
 
         when:
@@ -176,7 +176,7 @@ class DBSpecification extends Specification {
 
         then:
         expect operation, isTheSameAs(new CreateViewOperation(databaseName, viewName, viewOn,
-                [new BsonDocument('$match', new BsonDocument('x', BsonBoolean.TRUE))], writeConcern).collation(collation))
+                [new BsonDocument('$match', new BsonDocument('x', BsonBoolean.TRUE))], writeConcern, true, null).collation(collation))
         executor.getReadConcern() == ReadConcern.MAJORITY
     }
 

--- a/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
@@ -68,10 +68,11 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
             final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
             final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
             final List<? extends Bson> pipeline, final AggregationLevel aggregationLevel,
-            final boolean retryReads, @Nullable final Integer maxAdaptiveRetriesSetting,
+            final boolean retryWrites, final boolean retryReads, @Nullable final Integer maxAdaptiveRetriesSetting,
             final TimeoutSettings timeoutSettings) {
         this(clientSession, new MongoNamespace(databaseName, "_ignored"), documentClass, resultClass, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, pipeline, aggregationLevel, retryReads, maxAdaptiveRetriesSetting, timeoutSettings);
+                readConcern, writeConcern, executor, pipeline, aggregationLevel, retryWrites, retryReads, maxAdaptiveRetriesSetting,
+                timeoutSettings);
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber")
@@ -79,11 +80,11 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
             final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
             final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
             final List<? extends Bson> pipeline, final AggregationLevel aggregationLevel,
-            final boolean retryReads, @Nullable final Integer maxAdaptiveRetriesSetting,
+            final boolean retryWrites, final boolean retryReads, @Nullable final Integer maxAdaptiveRetriesSetting,
             final TimeoutSettings timeoutSettings) {
         super(clientSession, executor, readConcern, readPreference, retryReads, timeoutSettings);
         this.operations = new Operations<>(namespace, documentClass, readPreference, codecRegistry, readConcern, writeConcern,
-                true, retryReads, maxAdaptiveRetriesSetting, timeoutSettings);
+                retryWrites, retryReads, maxAdaptiveRetriesSetting, timeoutSettings);
         this.namespace = notNull("namespace", namespace);
         this.documentClass = notNull("documentClass", documentClass);
         this.resultClass = notNull("resultClass", resultClass);

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
@@ -364,7 +364,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
                                                                          final Class<TResult> resultClass) {
         return new AggregateIterableImpl<>(clientSession, namespace, documentClass, resultClass, codecRegistry,
                 readPreference, readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION,
-                retryReads, maxAdaptiveRetriesSetting, timeoutSettings);
+                retryWrites, retryReads, maxAdaptiveRetriesSetting, timeoutSettings);
     }
 
     @Override

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
@@ -399,7 +399,7 @@ public class MongoDatabaseImpl implements MongoDatabase {
                                                                          final Class<TResult> resultClass) {
         return new AggregateIterableImpl<>(clientSession, name, Document.class, resultClass, codecRegistry,
                 readPreference, readConcern, writeConcern, executor, pipeline, AggregationLevel.DATABASE,
-                retryReads, maxAdaptiveRetriesSetting, timeoutSettings);
+                retryWrites, retryReads, maxAdaptiveRetriesSetting, timeoutSettings);
     }
 
     private <TResult> ChangeStreamIterable<TResult> createChangeStreamIterable(@Nullable final ClientSession clientSession,

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -20,26 +20,36 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.MongoServerException;
+import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.Updates;
 import com.mongodb.client.model.bulk.ClientBulkWriteResult;
 import com.mongodb.client.model.bulk.ClientNamespacedWriteModel;
 import com.mongodb.event.CommandFailedEvent;
+import com.mongodb.event.CommandStartedEvent;
 import com.mongodb.internal.connection.TestCommandListener;
 import com.mongodb.internal.event.ConfigureFailPointCommandListener;
 import com.mongodb.internal.time.ExponentialBackoff;
 import com.mongodb.internal.time.StartTime;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
+import org.bson.BsonString;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static com.mongodb.client.model.bulk.ClientBulkWriteOptions.clientBulkWriteOptions;
 import static com.mongodb.client.model.bulk.ClientUpdateOneOptions.clientUpdateOneOptions;
@@ -68,6 +78,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * Prose Tests</a>.
  */
 public class BackpressureProseTest {
+    private static final String ENCRYPTED_STATE_COLLECTION_PREFIX = "enxcol_.";
+    private static final MongoNamespace NAMESPACE = new MongoNamespace(getDefaultDatabaseName(), BackpressureProseTest.class.getSimpleName());
     protected MongoClient createClient(final MongoClientSettings mongoClientSettings) {
         return MongoClients.create(mongoClientSettings);
     }
@@ -262,29 +274,8 @@ public class BackpressureProseTest {
      */
     @Test
     void runCommandDoesNotRetryOnRetryableWriteError() throws InterruptedException {
-        assumeTrue(serverVersionAtLeast(4, 4));
-        BsonDocument retryableWriteErrorFailPoint = BsonDocument.parse(
-                "{\n"
-                + "    configureFailPoint: 'failCommand',\n"
-                + "    mode: {times: 1},\n"
-                + "    data: {\n"
-                + "        failCommands: ['ping'],\n"
-                + "        errorCode: 11602,\n"
-                + "        errorLabels: ['" + RETRYABLE_WRITE_ERROR_LABEL + "']\n"
-                + "    }\n"
-                + "}\n");
-        TestCommandListener commandListener = new TestCommandListener();
-        try (MongoClient client = createClient(MongoClientSettings.builder(getMongoClientSettings())
-                .addCommandListener(commandListener)
-                .build());
-             FailPoint ignored = FailPoint.enable(retryableWriteErrorFailPoint, getPrimary())) {
-            MongoServerException exception = assertThrows(MongoServerException.class,
-                    () -> client.getDatabase("admin").runCommand(BsonDocument.parse("{ping: 1}")));
-            assertTrue(exception.hasErrorLabel(RETRYABLE_WRITE_ERROR_LABEL),
-                    "Expected RetryableWriteError, got: " + exception);
-            assertEquals(1, commandListener.getCommandStartedEvents("ping").size(),
-                    "Expected exactly one ping attempt (runCommand overload-only policy does not retry RetryableWriteError)");
-        }
+        assertCommandNotRetriedOnRetryableWriteError("ping",
+                client -> client.getDatabase("admin").runCommand(BsonDocument.parse("{ping: 1}")));
     }
 
     /**
@@ -336,28 +327,8 @@ public class BackpressureProseTest {
      */
     @Test
     void runCommandDoesNotRetryOnRetryableReadError() throws InterruptedException {
-        assumeTrue(serverVersionAtLeast(4, 4));
-        BsonDocument retryableReadErrorFailPoint = BsonDocument.parse(
-                "{\n"
-                + "    configureFailPoint: 'failCommand',\n"
-                + "    mode: {times: 1},\n"
-                + "    data: {\n"
-                + "        failCommands: ['ping'],\n"
-                + "        errorCode: 11602\n"
-                + "    }\n"
-                + "}\n");
-        TestCommandListener commandListener = new TestCommandListener();
-        try (MongoClient client = createClient(MongoClientSettings.builder(getMongoClientSettings())
-                .addCommandListener(commandListener)
-                .build());
-             FailPoint ignored = FailPoint.enable(retryableReadErrorFailPoint, getPrimary())) {
-            MongoServerException exception = assertThrows(MongoServerException.class,
-                    () -> client.getDatabase("admin").runCommand(BsonDocument.parse("{ping: 1}")));
-            assertEquals(11602, ((MongoCommandException) exception).getErrorCode(),
-                    "Expected retryable-read-style error, got: " + exception);
-            assertEquals(1, commandListener.getCommandStartedEvents("ping").size(),
-                    "Expected exactly one ping attempt (runCommand overload-only policy does not retry retryable-read codes)");
-        }
+        assertCommandNotRetriedOnRetryableReadError("ping",
+                client -> client.getDatabase("admin").runCommand(BsonDocument.parse("{ping: 1}")));
     }
 
     /**
@@ -460,31 +431,7 @@ public class BackpressureProseTest {
     @Test
     void clientBulkWriteGetMoreDoesNotRetryOverloadWhenRetryReadsDisabled() throws InterruptedException {
         assumeTrue(serverVersionAtLeast(8, 0));
-        BsonDocument overloadOnGetMoreOnce = BsonDocument.parse(
-                "{\n"
-                + "    configureFailPoint: 'failCommand',\n"
-                + "    mode: {times: 1},\n"
-                + "    data: {\n"
-                + "        failCommands: ['getMore'],\n"
-                + "        errorCode: 462,\n"
-                + "        errorLabels: ['" + SYSTEM_OVERLOADED_ERROR_LABEL + "', '" + RETRYABLE_ERROR_LABEL + "']\n"
-                + "    }\n"
-                + "}\n");
-        TestCommandListener commandListener = new TestCommandListener();
-        try (MongoClient client = createClient(MongoClientSettings.builder(getMongoClientSettings())
-                .retryWrites(false)
-                .retryReads(false)
-                .addCommandListener(commandListener)
-                .build())) {
-            try (FailPoint ignored = FailPoint.enable(overloadOnGetMoreOnce, getPrimary())) {
-                MongoServerException exception = assertThrows(MongoServerException.class,
-                        () -> executeClientBulkWrite(client));
-                assertTrue(exception.hasErrorLabel(SYSTEM_OVERLOADED_ERROR_LABEL),
-                        "Expected propagated overload error, got: " + exception);
-            }
-            assertEquals(1, commandListener.getCommandStartedEvents("getMore").size(),
-                    "Expected exactly one getMore attempt (retryReads=false disables overload retry for getMore)");
-        }
+        assertCommandNotRetriedWhenRetryReadsDisabled("getMore", BackpressureProseTest::executeClientBulkWrite);
     }
 
     private static ClientBulkWriteResult executeClientBulkWrite(final MongoClient client) {
@@ -507,15 +454,266 @@ public class BackpressureProseTest {
         return client.bulkWrite(models, clientBulkWriteOptions().verboseResults(true));
     }
 
-    /**
-     * Asserts that the supplied write command is overload-retried the expected number of times.
-     *
-     * @param commandName the server command name to fail with an overload error
-     * @param setUp       an optional setup invoked before the fail point is enabled (e.g. creating a collection)
-     * @param operation   the operation under test, invoked with the client
-     */
-    private void assertWriteCommandOverloadRetried(final String commandName, final Consumer<MongoClient> setUp,
-            final Consumer<MongoClient> operation) throws InterruptedException {
+    @Test
+    void createIndexesExhaustsOverloadRetriesAndThrows() throws InterruptedException {
+        assertCommandExhaustsOverloadRetries("createIndexes",
+                client -> getCollection(client).createIndex(new Document("a", 1)));
+    }
+
+    @Test
+    void dropIndexExhaustsOverloadRetriesAndThrows() throws InterruptedException {
+        assertCommandExhaustsOverloadRetries("dropIndexes",
+                client -> getCollection(client).dropIndex(new Document("a", 1)));
+    }
+
+    @Test
+    void createViewExhaustsOverloadRetriesAndThrows() throws InterruptedException {
+        assertCommandExhaustsOverloadRetries("create",
+                client -> client.getDatabase(NAMESPACE.getDatabaseName())
+                        .createView(NAMESPACE.getCollectionName() + "View", NAMESPACE.getCollectionName(),
+                                asList(new Document("$match", new Document()))));
+    }
+
+    @Test
+    void dropCollectionExhaustsOverloadRetriesAndThrows() throws InterruptedException {
+        assertCommandExhaustsOverloadRetries("drop", client -> getCollection(client).drop());
+    }
+
+    @Test
+    void dropDatabaseExhaustsOverloadRetriesAndThrows() throws InterruptedException {
+        assertCommandExhaustsOverloadRetries("dropDatabase",
+                client -> client.getDatabase(NAMESPACE.getDatabaseName()).drop());
+    }
+
+    @Test
+    void renameCollectionExhaustsOverloadRetriesAndThrows() throws InterruptedException {
+        assertCommandExhaustsOverloadRetries("renameCollection",
+                client -> getCollection(client).renameCollection(
+                        new MongoNamespace(NAMESPACE.getDatabaseName(), NAMESPACE.getCollectionName() + "Renamed")));
+    }
+
+    @Test
+    void createSearchIndexesExhaustsOverloadRetriesAndThrows() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(6, 0));
+        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+        assertCommandExhaustsOverloadRetries("createSearchIndexes",
+                client -> getCollection(client).createSearchIndexes(
+                        singletonList(new SearchIndexModel(new Document("mappings", new Document("dynamic", true))))));
+    }
+
+    @Test
+    void updateSearchIndexExhaustsOverloadRetriesAndThrows() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(6, 0));
+        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+        assertCommandExhaustsOverloadRetries("updateSearchIndex",
+                client -> getCollection(client).updateSearchIndex("default", new Document("mappings", new Document("dynamic", true))));
+    }
+
+    @Test
+    void dropSearchIndexExhaustsOverloadRetriesAndThrows() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(6, 0));
+        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+        assertCommandExhaustsOverloadRetries("dropSearchIndex",
+                client -> getCollection(client).dropSearchIndex("default"));
+    }
+
+    @Test
+    void createCollectionExhaustsOverloadRetriesAndThrows() throws InterruptedException {
+        assertCommandExhaustsOverloadRetries("create",
+                client -> client.getDatabase(NAMESPACE.getDatabaseName()).createCollection(NAMESPACE.getCollectionName()));
+    }
+
+
+    @Test
+    void createIndexesDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
+        assertCommandNotRetriedWhenRetryWritesDisabled("createIndexes",
+                client -> getCollection(client).createIndex(new Document("a", 1)));
+    }
+
+    @Test
+    void dropIndexDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
+        assertCommandNotRetriedWhenRetryWritesDisabled("dropIndexes",
+                client -> getCollection(client).dropIndex(new Document("a", 1)));
+    }
+
+    @Test
+    void createViewDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
+        assertCommandNotRetriedWhenRetryWritesDisabled("create",
+                client -> client.getDatabase(NAMESPACE.getDatabaseName())
+                        .createView(NAMESPACE.getCollectionName() + "View", NAMESPACE.getCollectionName(),
+                                asList(new Document("$match", new Document()))));
+    }
+
+    @Test
+    void dropCollectionDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
+        assertCommandNotRetriedWhenRetryWritesDisabled("drop", client -> getCollection(client).drop());
+    }
+
+    @Test
+    void dropDatabaseDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
+        assertCommandNotRetriedWhenRetryWritesDisabled("dropDatabase",
+                client -> client.getDatabase(NAMESPACE.getDatabaseName()).drop());
+    }
+
+    @Test
+    void renameCollectionDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
+        assertCommandNotRetriedWhenRetryWritesDisabled("renameCollection",
+                client -> getCollection(client).renameCollection(
+                        new MongoNamespace(NAMESPACE.getDatabaseName(), NAMESPACE.getCollectionName() + "Renamed")));
+    }
+
+    @Test
+    void createCollectionDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
+        assertCommandNotRetriedWhenRetryWritesDisabled("create",
+                client -> client.getDatabase(NAMESPACE.getDatabaseName()).createCollection(NAMESPACE.getCollectionName()));
+    }
+
+    @Test
+    void createSearchIndexesDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(6, 0));
+        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+        assertCommandNotRetriedWhenRetryWritesDisabled("createSearchIndexes",
+                client -> getCollection(client).createSearchIndexes(
+                        singletonList(new SearchIndexModel(new Document("mappings", new Document("dynamic", true))))));
+    }
+
+    @Test
+    void updateSearchIndexDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(6, 0));
+        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+        assertCommandNotRetriedWhenRetryWritesDisabled("updateSearchIndex",
+                client -> getCollection(client).updateSearchIndex("default", new Document("mappings", new Document("dynamic", true))));
+    }
+
+    @Test
+    void dropSearchIndexDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(6, 0));
+        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+        assertCommandNotRetriedWhenRetryWritesDisabled("dropSearchIndex",
+                client -> getCollection(client).dropSearchIndex("default"));
+    }
+
+    @Test
+    void createIndexesDoesNotRetryOnRetryableWriteError() throws InterruptedException {
+        assertCommandNotRetriedOnRetryableWriteError("createIndexes",
+                client -> getCollection(client).createIndex(new Document("a", 1)));
+    }
+
+    @Test
+    void dropIndexDoesNotRetryOnRetryableWriteError() throws InterruptedException {
+        assertCommandNotRetriedOnRetryableWriteError("dropIndexes",
+                client -> getCollection(client).dropIndex(new Document("a", 1)));
+    }
+
+    @Test
+    void createViewDoesNotRetryOnRetryableWriteError() throws InterruptedException {
+        assertCommandNotRetriedOnRetryableWriteError("create",
+                client -> client.getDatabase(NAMESPACE.getDatabaseName())
+                        .createView(NAMESPACE.getCollectionName() + "View", NAMESPACE.getCollectionName(),
+                                asList(new Document("$match", new Document()))));
+    }
+
+    @Test
+    void dropCollectionDoesNotRetryOnRetryableWriteError() throws InterruptedException {
+        assertCommandNotRetriedOnRetryableWriteError("drop", client -> getCollection(client).drop());
+    }
+
+    @Test
+    void dropDatabaseDoesNotRetryOnRetryableWriteError() throws InterruptedException {
+        assertCommandNotRetriedOnRetryableWriteError("dropDatabase",
+                client -> client.getDatabase(NAMESPACE.getDatabaseName()).drop());
+    }
+
+    @Test
+    void renameCollectionDoesNotRetryOnRetryableWriteError() throws InterruptedException {
+        assertCommandNotRetriedOnRetryableWriteError("renameCollection",
+                client -> getCollection(client).renameCollection(
+                        new MongoNamespace(NAMESPACE.getDatabaseName(), NAMESPACE.getCollectionName() + "Renamed")));
+    }
+
+    @Test
+    void createCollectionDoesNotRetryOnRetryableWriteError() throws InterruptedException {
+        assertCommandNotRetriedOnRetryableWriteError("create",
+                client -> client.getDatabase(NAMESPACE.getDatabaseName()).createCollection(NAMESPACE.getCollectionName()));
+    }
+
+    @Test
+    void createSearchIndexesDoesNotRetryOnRetryableWriteError() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(6, 0));
+        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+        assertCommandNotRetriedOnRetryableWriteError("createSearchIndexes",
+                client -> getCollection(client).createSearchIndexes(
+                        singletonList(new SearchIndexModel(new Document("mappings", new Document("dynamic", true))))));
+    }
+
+    @Test
+    void updateSearchIndexDoesNotRetryOnRetryableWriteError() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(6, 0));
+        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+        assertCommandNotRetriedOnRetryableWriteError("updateSearchIndex",
+                client -> getCollection(client).updateSearchIndex("default", new Document("mappings", new Document("dynamic", true))));
+    }
+
+    @Test
+    void dropSearchIndexDoesNotRetryOnRetryableWriteError() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(6, 0));
+        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+        assertCommandNotRetriedOnRetryableWriteError("dropSearchIndex",
+                client -> getCollection(client).dropSearchIndex("default"));
+    }
+
+    private static Stream<Arguments> createEncryptedCollectionRetriesEachCommandIndependently() {
+        String collectionName = NAMESPACE.getCollectionName();
+        List<BsonDocument> commandSequence = asList(
+                new BsonDocument("create", new BsonString(ENCRYPTED_STATE_COLLECTION_PREFIX + collectionName + ".esc")),
+                new BsonDocument("create", new BsonString(ENCRYPTED_STATE_COLLECTION_PREFIX + collectionName + ".ecoc")),
+                new BsonDocument("create", new BsonString(collectionName)),
+                new BsonDocument("createIndexes", new BsonString(collectionName)));
+        return IntStream.range(0, commandSequence.size()).mapToObj(failingCommandIndex -> {
+            BsonDocument failingCommand = commandSequence.get(failingCommandIndex);
+            List<BsonDocument> expectedCommands = new ArrayList<>(commandSequence.subList(0, failingCommandIndex));
+            expectedCommands.addAll(nCopies(DEFAULT_MAX_ADAPTIVE_RETRIES + 1, failingCommand));
+            return Arguments.of(failingCommand, failingCommandIndex, expectedCommands);
+        });
+    }
+
+    @ParameterizedTest(name = "createEncryptedCollectionRetriesEachCommandIndependently. failingCommand={0}, failPointSkip=={0}")
+    @MethodSource
+    void createEncryptedCollectionRetriesEachCommandIndependently(
+            final BsonDocument failingCommand,
+            final int failPointSkip,
+            final List<BsonDocument> expectedCommands) throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(7, 0));
+        TestCommandListener commandListener = new TestCommandListener();
+        // The failPoint fails every command of the sequence, so `skip` is the number of the commands preceding the
+        // failing one. It lets them pass through and then fails every subsequent one, so that all the retries of a
+        // single command in the sequence are exhausted.
+        BsonDocument configureFailPoint = BsonDocument.parse(
+                "{\n"
+                        + "    configureFailPoint: 'failCommand',\n"
+                        + "    mode: {skip: " + failPointSkip + "},\n"
+                        + "    data: {\n"
+                        + "        failCommands: ['create', 'createIndexes'],\n"
+                        + "        errorCode: 462,\n"
+                        + "        errorLabels: ['" + SYSTEM_OVERLOADED_ERROR_LABEL + "', '" + RETRYABLE_ERROR_LABEL + "']\n"
+                        + "    }\n"
+                        + "}\n");
+        try (MongoClient client = createClient(MongoClientSettings.builder(getMongoClientSettings())
+                .addCommandListener(commandListener)
+                .build())) {
+            MongoDatabase database = client.getDatabase(NAMESPACE.getDatabaseName());
+            try (FailPoint ignored = FailPoint.enable(configureFailPoint, getPrimary())) {
+                commandListener.reset();
+                MongoServerException e = assertThrows(MongoServerException.class, () -> database.createCollection(
+                        NAMESPACE.getCollectionName(), encryptedCollectionOptions()));
+                assertEquals(462, e.getCode());
+                assertCommandsStarted(expectedCommands, commandListener);
+            }
+        }
+    }
+
+    private void assertCommandExhaustsOverloadRetries(final String commandName, final Consumer<MongoClient> operation)
+            throws InterruptedException {
         assumeTrue(serverVersionAtLeast(4, 4));
         TestCommandListener commandListener = new TestCommandListener();
         BsonDocument configureFailPoint = BsonDocument.parse(
@@ -531,7 +729,6 @@ public class BackpressureProseTest {
         try (MongoClient client = createClient(MongoClientSettings.builder(getMongoClientSettings())
                 .addCommandListener(commandListener)
                 .build())) {
-            setUp.accept(client);
             try (FailPoint ignored = FailPoint.enable(configureFailPoint, getPrimary())) {
                 commandListener.reset();
                 assertThrows(MongoServerException.class, () -> operation.accept(client));
@@ -542,105 +739,90 @@ public class BackpressureProseTest {
         }
     }
 
-    @Test
-    void createIndexesOverloadRetries() throws InterruptedException {
-        assertWriteCommandOverloadRetried("createIndexes",
-                client -> dropAndGetCollection("createIndexesOverloadRetries", client),
-                client -> client.getDatabase(getDefaultDatabaseName()).getCollection("createIndexesOverloadRetries")
-                        .createIndex(new Document("a", 1)));
+    private void assertCommandNotRetriedOnRetryableWriteError(final String commandName, final Consumer<MongoClient> operation)
+            throws InterruptedException {
+        assertCommandNotRetriedOnNonOverloadError(commandName, operation, RETRYABLE_WRITE_ERROR_LABEL);
     }
 
-    @Test
-    void dropIndexOverloadRetries() throws InterruptedException {
-        assertWriteCommandOverloadRetried("dropIndexes",
-                client -> {
-                    MongoCollection<Document> coll = dropAndGetCollection("dropIndexOverloadRetries", client);
-                    coll.createIndex(new Document("a", 1));
-                },
-                client -> client.getDatabase(getDefaultDatabaseName()).getCollection("dropIndexOverloadRetries")
-                        .dropIndex(new Document("a", 1)));
+    private void assertCommandNotRetriedOnRetryableReadError(final String commandName, final Consumer<MongoClient> operation)
+            throws InterruptedException {
+        assertCommandNotRetriedOnNonOverloadError(commandName, operation, null);
     }
 
-    @Test
-    void createCollectionOverloadRetries() throws InterruptedException {
-        assertWriteCommandOverloadRetried("create",
-                client -> client.getDatabase(getDefaultDatabaseName()).getCollection("createCollectionOverloadRetries").drop(),
-                client -> client.getDatabase(getDefaultDatabaseName()).createCollection("createCollectionOverloadRetries"));
+    private void assertCommandNotRetriedOnNonOverloadError(final String commandName, final Consumer<MongoClient> operation,
+                                                           @Nullable final String errorLabel)
+            throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(4, 4));
+        TestCommandListener commandListener = new TestCommandListener();
+        BsonDocument configureFailPoint = BsonDocument.parse(
+                "{\n"
+                        + "    configureFailPoint: 'failCommand',\n"
+                        + "    mode: {times: 1},\n"
+                        + "    data: {\n"
+                        + "        failCommands: ['" + commandName + "'],\n"
+                        + "        errorCode: 11602,\n"
+                        + "        errorLabels: [" + (errorLabel == null ? "" : "'" + errorLabel + "'") + "]\n"
+                        + "    }\n"
+                        + "}\n");
+        try (MongoClient client = createClient(MongoClientSettings.builder(getMongoClientSettings())
+                .addCommandListener(commandListener)
+                .build())) {
+            try (FailPoint ignored = FailPoint.enable(configureFailPoint, getPrimary())) {
+                commandListener.reset();
+                MongoServerException exception = assertThrows(MongoServerException.class, () -> operation.accept(client));
+                assertEquals(11602, ((MongoCommandException) exception).getErrorCode(),
+                        format("Expected the propagated non-overload error, got: %s", exception));
+                if (errorLabel != null) {
+                    assertTrue(exception.hasErrorLabel(errorLabel),
+                            format("Expected the propagated error to have the %s label, got: %s", errorLabel, exception));
+                }
+                assertEquals(1, commandListener.getCommandStartedEvents(commandName).size(),
+                        format("Expected exactly one attempt of %s, as the overload-only policy does not retry"
+                                + " non-overload errors", commandName));
+            }
+        }
     }
 
-    @Test
-    void createViewOverloadRetries() throws InterruptedException {
-        assertWriteCommandOverloadRetried("create",
-                client -> {
-                    MongoCollection<Document> source = dropAndGetCollection("createViewOverloadRetriesSource", client);
-                    source.insertOne(new Document());
-                },
-                client -> client.getDatabase(getDefaultDatabaseName())
-                        .createView("createViewOverloadRetries", "createViewOverloadRetriesSource",
-                                asList(new Document("$match", new Document()))));
+    private void assertCommandNotRetriedWhenRetryWritesDisabled(final String commandName, final Consumer<MongoClient> operation)
+            throws InterruptedException {
+        assertCommandNotOverloadRetried(commandName, operation, true, false);
     }
 
-    @Test
-    void dropCollectionOverloadRetries() throws InterruptedException {
-        assertWriteCommandOverloadRetried("drop",
-                client -> dropAndGetCollection("dropCollectionOverloadRetries", client),
-                client -> client.getDatabase(getDefaultDatabaseName()).getCollection("dropCollectionOverloadRetries").drop());
+    private void assertCommandNotRetriedWhenRetryReadsDisabled(final String commandName, final Consumer<MongoClient> operation)
+            throws InterruptedException {
+        assertCommandNotOverloadRetried(commandName, operation, false, true);
     }
 
-    @Test
-    void dropDatabaseOverloadRetries() throws InterruptedException {
-        assertWriteCommandOverloadRetried("dropDatabase",
-                client -> {
-                    // no setup required
-                },
-                client -> client.getDatabase(getDefaultDatabaseName()).drop());
-    }
-
-    @Test
-    void renameCollectionOverloadRetries() throws InterruptedException {
-        assertWriteCommandOverloadRetried("renameCollection",
-                client -> dropAndGetCollection("renameCollectionOverloadRetriesSource", client),
-                client -> {
-                    MongoDatabase database = client.getDatabase(getDefaultDatabaseName());
-                    database.getCollection("renameCollectionOverloadRetriesSource")
-                            .renameCollection(new MongoNamespace(getDefaultDatabaseName(), "renameCollectionOverloadRetries"));
-                });
-    }
-
-    @Test
-    void createSearchIndexesOverloadRetries() throws InterruptedException {
-        assumeTrue(serverVersionAtLeast(6, 0));
-        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
-        assertWriteCommandOverloadRetried("createSearchIndexes",
-                client -> dropAndGetCollection("createSearchIndexesOverloadRetries", client),
-                client -> client.getDatabase(getDefaultDatabaseName()).getCollection("createSearchIndexesOverloadRetries")
-                        .createSearchIndexes(singletonList(new SearchIndexModel(new Document("mappings", new Document("dynamic", true))))));
-    }
-
-    @Test
-    void updateSearchIndexOverloadRetries() throws InterruptedException {
-        assumeTrue(serverVersionAtLeast(6, 0));
-        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
-        assertWriteCommandOverloadRetried("updateSearchIndex",
-                client -> {
-                    MongoCollection<Document> coll = dropAndGetCollection("updateSearchIndexOverloadRetries", client);
-                    coll.createSearchIndex(new Document("mappings", new Document("dynamic", true)));
-                },
-                client -> client.getDatabase(getDefaultDatabaseName()).getCollection("updateSearchIndexOverloadRetries")
-                        .updateSearchIndex("default", new Document("mappings", new Document("dynamic", true))));
-    }
-
-    @Test
-    void dropSearchIndexOverloadRetries() throws InterruptedException {
-        assumeTrue(serverVersionAtLeast(6, 0));
-        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
-        assertWriteCommandOverloadRetried("dropSearchIndex",
-                client -> {
-                    MongoCollection<Document> coll = dropAndGetCollection("dropSearchIndexOverloadRetries", client);
-                    coll.createSearchIndex(new Document("mappings", new Document("dynamic", true)));
-                },
-                client -> client.getDatabase(getDefaultDatabaseName()).getCollection("dropSearchIndexOverloadRetries")
-                        .dropSearchIndex("default"));
+    private void assertCommandNotOverloadRetried(final String commandName, final Consumer<MongoClient> operation,
+                                         final boolean retryReads, final boolean retryWrites)
+            throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(4, 4));
+        TestCommandListener commandListener = new TestCommandListener();
+        BsonDocument configureFailPoint = BsonDocument.parse(
+                "{\n"
+                        + "    configureFailPoint: 'failCommand',\n"
+                        + "    mode: 'alwaysOn',\n"
+                        + "    data: {\n"
+                        + "        failCommands: ['" + commandName + "'],\n"
+                        + "        errorCode: 462,\n"
+                        + "        errorLabels: ['" + SYSTEM_OVERLOADED_ERROR_LABEL + "', '" + RETRYABLE_ERROR_LABEL + "']\n"
+                        + "    }\n"
+                        + "}\n");
+        try (MongoClient client = createClient(MongoClientSettings.builder(getMongoClientSettings())
+                .retryReads(retryReads)
+                .retryWrites(retryWrites)
+                .addCommandListener(commandListener)
+                .build())) {
+            try (FailPoint ignored = FailPoint.enable(configureFailPoint, getPrimary())) {
+                commandListener.reset();
+                MongoServerException exception = assertThrows(MongoServerException.class, () -> operation.accept(client));
+                assertTrue(exception.hasErrorLabel(SYSTEM_OVERLOADED_ERROR_LABEL),
+                        "Expected propagated overload error, got: " + exception);
+                assertEquals(1, commandListener.getCommandStartedEvents(commandName).size(),
+                        format("Expected exactly one attempt of %s, as retryReads=%b, retryWrites=%b disable the"
+                                + " overload retry", commandName, retryReads, retryWrites));
+            }
+        }
     }
 
     private static boolean hasAtlasSearchIndexHelperEnabled() {
@@ -651,5 +833,34 @@ public class BackpressureProseTest {
         MongoCollection<Document> result = client.getDatabase(getDefaultDatabaseName()).getCollection(name);
         result.drop();
         return result;
+    }
+
+    /**
+     * Asserts that the commands started by the {@code commandListener} are exactly the {@code expectedCommands}, in
+     * order. Each expected command is required to be a subset of the actual one, so that it has to specify only the
+     * entries identifying the command.
+     */
+    private static void assertCommandsStarted(final List<BsonDocument> expectedCommands,
+                                              final TestCommandListener commandListener) {
+        List<BsonDocument> actualCommands = commandListener.getCommandStartedEvents().stream()
+                .map(CommandStartedEvent::getCommand)
+                .collect(Collectors.toList());
+        assertEquals(expectedCommands.size(), actualCommands.size(),
+                format("Expected %s but observed %s", expectedCommands, actualCommands));
+        for (int i = 0; i < expectedCommands.size(); i++) {
+            BsonDocument expected = expectedCommands.get(i);
+            BsonDocument actual = actualCommands.get(i);
+            assertTrue(actual.entrySet().containsAll(expected.entrySet()),
+                    format("Expected the command at index %d to contain %s but it was %s", i, expected, actual));
+        }
+    }
+
+    private static CreateCollectionOptions encryptedCollectionOptions() {
+        return new CreateCollectionOptions().encryptedFields(BsonDocument.parse(
+                "{fields: [{path: 'ssn', bsonType: 'string',"
+                        + " keyId: {$binary: {base64: 'AAAAAAAAAAAAAAAAAAAAAA==', subType: '04'}}}]}"));
+    }
+    private static MongoCollection<Document> getCollection(final MongoClient client) {
+        return client.getDatabase(NAMESPACE.getDatabaseName()).getCollection(NAMESPACE.getCollectionName());
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -20,9 +20,11 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.MongoServerException;
+import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.DropCollectionOptions;
 import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Indexes;
 import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.Updates;
 import com.mongodb.client.model.bulk.ClientBulkWriteResult;
@@ -52,6 +54,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static com.mongodb.client.model.Aggregates.match;
+import static com.mongodb.client.model.Indexes.ascending;
 import static com.mongodb.client.model.bulk.ClientBulkWriteOptions.clientBulkWriteOptions;
 import static com.mongodb.client.model.bulk.ClientUpdateOneOptions.clientUpdateOneOptions;
 import static java.lang.String.join;
@@ -457,38 +461,38 @@ public class BackpressureProseTest {
 
     @Test
     void createIndexesExhaustsOverloadRetriesAndThrows() throws InterruptedException {
-        assertCommandExhaustsOverloadRetries("createIndexes",
-                client -> getCollection(client).createIndex(new Document("a", 1)));
+        assertCommandExhaustsOverloadRetriesAndThrows("createIndexes",
+                client -> getCollection(client).createIndex(ascending("a")));
     }
 
     @Test
     void dropIndexExhaustsOverloadRetriesAndThrows() throws InterruptedException {
-        assertCommandExhaustsOverloadRetries("dropIndexes",
-                client -> getCollection(client).dropIndex(new Document("a", 1)));
+        assertCommandExhaustsOverloadRetriesAndThrows("dropIndexes",
+                client -> getCollection(client).dropIndex(ascending("a")));
     }
 
     @Test
     void createViewExhaustsOverloadRetriesAndThrows() throws InterruptedException {
-        assertCommandExhaustsOverloadRetries("create",
+        assertCommandExhaustsOverloadRetriesAndThrows("create",
                 client -> client.getDatabase(NAMESPACE.getDatabaseName())
                         .createView(NAMESPACE.getCollectionName() + "View", NAMESPACE.getCollectionName(),
-                                asList(new Document("$match", new Document()))));
+                                singletonList(match(new Document()))));
     }
 
     @Test
     void dropCollectionExhaustsOverloadRetriesAndThrows() throws InterruptedException {
-        assertCommandExhaustsOverloadRetries("drop", client -> getCollection(client).drop());
+        assertCommandExhaustsOverloadRetriesAndThrows("drop", client -> getCollection(client).drop());
     }
 
     @Test
     void dropDatabaseExhaustsOverloadRetriesAndThrows() throws InterruptedException {
-        assertCommandExhaustsOverloadRetries("dropDatabase",
+        assertCommandExhaustsOverloadRetriesAndThrows("dropDatabase",
                 client -> client.getDatabase(NAMESPACE.getDatabaseName()).drop());
     }
 
     @Test
     void renameCollectionExhaustsOverloadRetriesAndThrows() throws InterruptedException {
-        assertCommandExhaustsOverloadRetries("renameCollection",
+        assertCommandExhaustsOverloadRetriesAndThrows("renameCollection",
                 client -> getCollection(client).renameCollection(
                         new MongoNamespace(NAMESPACE.getDatabaseName(), NAMESPACE.getCollectionName() + "Renamed")));
     }
@@ -497,7 +501,7 @@ public class BackpressureProseTest {
     void createSearchIndexesExhaustsOverloadRetriesAndThrows() throws InterruptedException {
         assumeTrue(serverVersionAtLeast(6, 0));
         assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
-        assertCommandExhaustsOverloadRetries("createSearchIndexes",
+        assertCommandExhaustsOverloadRetriesAndThrows("createSearchIndexes",
                 client -> getCollection(client).createSearchIndexes(
                         singletonList(new SearchIndexModel(new Document("mappings", new Document("dynamic", true))))));
     }
@@ -506,7 +510,7 @@ public class BackpressureProseTest {
     void updateSearchIndexExhaustsOverloadRetriesAndThrows() throws InterruptedException {
         assumeTrue(serverVersionAtLeast(6, 0));
         assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
-        assertCommandExhaustsOverloadRetries("updateSearchIndex",
+        assertCommandExhaustsOverloadRetriesAndThrows("updateSearchIndex",
                 client -> getCollection(client).updateSearchIndex("default", new Document("mappings", new Document("dynamic", true))));
     }
 
@@ -514,13 +518,13 @@ public class BackpressureProseTest {
     void dropSearchIndexExhaustsOverloadRetriesAndThrows() throws InterruptedException {
         assumeTrue(serverVersionAtLeast(6, 0));
         assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
-        assertCommandExhaustsOverloadRetries("dropSearchIndex",
+        assertCommandExhaustsOverloadRetriesAndThrows("dropSearchIndex",
                 client -> getCollection(client).dropSearchIndex("default"));
     }
 
     @Test
     void createCollectionExhaustsOverloadRetriesAndThrows() throws InterruptedException {
-        assertCommandExhaustsOverloadRetries("create",
+        assertCommandExhaustsOverloadRetriesAndThrows("create",
                 client -> client.getDatabase(NAMESPACE.getDatabaseName()).createCollection(NAMESPACE.getCollectionName()));
     }
 
@@ -528,13 +532,13 @@ public class BackpressureProseTest {
     @Test
     void createIndexesDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
         assertCommandNotRetriedWhenRetryWritesDisabled("createIndexes",
-                client -> getCollection(client).createIndex(new Document("a", 1)));
+                client -> getCollection(client).createIndex(ascending("a")));
     }
 
     @Test
     void dropIndexDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
         assertCommandNotRetriedWhenRetryWritesDisabled("dropIndexes",
-                client -> getCollection(client).dropIndex(new Document("a", 1)));
+                client -> getCollection(client).dropIndex(ascending("a")));
     }
 
     @Test
@@ -542,7 +546,7 @@ public class BackpressureProseTest {
         assertCommandNotRetriedWhenRetryWritesDisabled("create",
                 client -> client.getDatabase(NAMESPACE.getDatabaseName())
                         .createView(NAMESPACE.getCollectionName() + "View", NAMESPACE.getCollectionName(),
-                                asList(new Document("$match", new Document()))));
+                                singletonList(match(new Document()))));
     }
 
     @Test
@@ -597,13 +601,13 @@ public class BackpressureProseTest {
     @Test
     void createIndexesDoesNotRetryOnRetryableWriteError() throws InterruptedException {
         assertCommandNotRetriedOnRetryableWriteError("createIndexes",
-                client -> getCollection(client).createIndex(new Document("a", 1)));
+                client -> getCollection(client).createIndex(ascending("a")));
     }
 
     @Test
     void dropIndexDoesNotRetryOnRetryableWriteError() throws InterruptedException {
         assertCommandNotRetriedOnRetryableWriteError("dropIndexes",
-                client -> getCollection(client).dropIndex(new Document("a", 1)));
+                client -> getCollection(client).dropIndex(ascending("a")));
     }
 
     @Test
@@ -611,7 +615,7 @@ public class BackpressureProseTest {
         assertCommandNotRetriedOnRetryableWriteError("create",
                 client -> client.getDatabase(NAMESPACE.getDatabaseName())
                         .createView(NAMESPACE.getCollectionName() + "View", NAMESPACE.getCollectionName(),
-                                asList(new Document("$match", new Document()))));
+                                singletonList(match(new Document()))));
     }
 
     @Test
@@ -761,7 +765,7 @@ public class BackpressureProseTest {
         }
     }
 
-    private void assertCommandExhaustsOverloadRetries(final String commandName, final Consumer<MongoClient> operation)
+    private void assertCommandExhaustsOverloadRetriesAndThrows(final String commandName, final Consumer<MongoClient> operation)
             throws InterruptedException {
         assumeTrue(serverVersionAtLeast(4, 4));
         TestCommandListener commandListener = new TestCommandListener();

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -676,13 +676,20 @@ public class BackpressureProseTest {
                 new BsonDocument("createIndexes", new BsonString(collectionName)));
         return IntStream.range(0, commandSequence.size()).mapToObj(failingCommandIndex -> {
             BsonDocument failingCommand = commandSequence.get(failingCommandIndex);
+            String failingCommandName = failingCommand.getFirstKey();
+            // `skip` is the number of commands preceding the failing one that share its name, since the failPoint
+            // only targets the failing command's name. This keeps the count correct regardless of whether the
+            // server tracks skip globally or per failCommand entry.
+            long failPointSkip = commandSequence.subList(0, failingCommandIndex).stream()
+                    .filter(command -> failingCommandName.equals(command.getFirstKey()))
+                    .count();
             List<BsonDocument> expectedCommands = new ArrayList<>(commandSequence.subList(0, failingCommandIndex));
             expectedCommands.addAll(nCopies(DEFAULT_MAX_ADAPTIVE_RETRIES + 1, failingCommand));
-            return Arguments.of(failingCommand, failingCommandIndex, expectedCommands);
+            return Arguments.of(failingCommand, (int) failPointSkip, expectedCommands);
         });
     }
 
-    @ParameterizedTest(name = "createEncryptedCollectionRetriesEachCommandIndependently. failingCommand={0}, failPointSkip=={0}")
+    @ParameterizedTest(name = "createEncryptedCollectionRetriesEachCommandIndependently. failingCommand={0}, failPointSkip=={1}")
     @MethodSource
     void createEncryptedCollectionRetriesEachCommandIndependently(
             final BsonDocument failingCommand,
@@ -690,15 +697,16 @@ public class BackpressureProseTest {
             final List<BsonDocument> expectedCommands) throws InterruptedException {
         assumeTrue(serverVersionAtLeast(7, 0));
         TestCommandListener commandListener = new TestCommandListener();
-        // The failPoint fails every command of the sequence, so `skip` is the number of the commands preceding the
-        // failing one. It lets them pass through and then fails every subsequent one, so that all the retries of a
-        // single command in the sequence are exhausted.
+        // The failPoint only targets the failing command's name, and `skip` is the number of same-name commands
+        // preceding it, so those pass through and every subsequent matching command (i.e. the retries of the one
+        // command under test) is failed until its retries are exhausted.
+        String failCommandName = failingCommand.getFirstKey();
         BsonDocument configureFailPoint = BsonDocument.parse(
                 "{\n"
                         + "    configureFailPoint: 'failCommand',\n"
                         + "    mode: {skip: " + failPointSkip + "},\n"
                         + "    data: {\n"
-                        + "        failCommands: ['create', 'createIndexes'],\n"
+                        + "        failCommands: ['" + failCommandName + "'],\n"
                         + "        errorCode: 462,\n"
                         + "        errorLabels: ['" + SYSTEM_OVERLOADED_ERROR_LABEL + "', '" + RETRYABLE_ERROR_LABEL + "']\n"
                         + "    }\n"

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -84,6 +84,8 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  */
 public class BackpressureProseTest {
     private static final String ENCRYPTED_STATE_COLLECTION_PREFIX = "enxcol_.";
+    private static final int SYSTEM_OVERLOAD_ERROR_CODE = 462;
+    private static final int RETRYABLE_ERROR_CODE = 11602;
     private static final MongoNamespace NAMESPACE = new MongoNamespace(getDefaultDatabaseName(), BackpressureProseTest.class.getSimpleName());
     protected MongoClient createClient(final MongoClientSettings mongoClientSettings) {
         return MongoClients.create(mongoClientSettings);
@@ -476,7 +478,7 @@ public class BackpressureProseTest {
         assertCommandExhaustsOverloadRetriesAndThrows("create",
                 client -> client.getDatabase(NAMESPACE.getDatabaseName())
                         .createView(NAMESPACE.getCollectionName() + "View", NAMESPACE.getCollectionName(),
-                                singletonList(match(new Document()))));
+                                singletonList(match(Filters.empty()))));
     }
 
     @Test
@@ -546,7 +548,7 @@ public class BackpressureProseTest {
         assertCommandNotRetriedWhenRetryWritesDisabled("create",
                 client -> client.getDatabase(NAMESPACE.getDatabaseName())
                         .createView(NAMESPACE.getCollectionName() + "View", NAMESPACE.getCollectionName(),
-                                singletonList(match(new Document()))));
+                                singletonList(match(Filters.empty()))));
     }
 
     @Test
@@ -615,7 +617,7 @@ public class BackpressureProseTest {
         assertCommandNotRetriedOnRetryableWriteError("create",
                 client -> client.getDatabase(NAMESPACE.getDatabaseName())
                         .createView(NAMESPACE.getCollectionName() + "View", NAMESPACE.getCollectionName(),
-                                singletonList(match(new Document()))));
+                                singletonList(match(Filters.empty()))));
     }
 
     @Test
@@ -674,18 +676,13 @@ public class BackpressureProseTest {
                 new BsonDocument("create", new BsonString(ENCRYPTED_STATE_COLLECTION_PREFIX + collectionName + ".ecoc")),
                 new BsonDocument("create", new BsonString(collectionName)),
                 new BsonDocument("createIndexes", new BsonString(collectionName)));
+        // QE createCollection issues the command sequence above; we generate one variant per command in round-robin,
+        // where that command is the one expected to fail and exhaust its overload retries.
         return IntStream.range(0, commandSequence.size()).mapToObj(failingCommandIndex -> {
             BsonDocument failingCommand = commandSequence.get(failingCommandIndex);
-            String failingCommandName = failingCommand.getFirstKey();
-            // `skip` is the number of commands preceding the failing one that share its name, since the failPoint
-            // only targets the failing command's name. This keeps the count correct regardless of whether the
-            // server tracks skip globally or per failCommand entry.
-            long failPointSkip = commandSequence.subList(0, failingCommandIndex).stream()
-                    .filter(command -> failingCommandName.equals(command.getFirstKey()))
-                    .count();
             List<BsonDocument> expectedCommands = new ArrayList<>(commandSequence.subList(0, failingCommandIndex));
             expectedCommands.addAll(nCopies(DEFAULT_MAX_ADAPTIVE_RETRIES + 1, failingCommand));
-            return Arguments.of(failingCommand, (int) failPointSkip, expectedCommands);
+            return Arguments.of(failingCommand, failingCommandIndex, expectedCommands);
         });
     }
 
@@ -698,17 +695,16 @@ public class BackpressureProseTest {
         assumeTrue(serverVersionAtLeast(7, 0));
         assumeFalse(isStandalone(), "Encrypted collections are not supported on standalone");
         TestCommandListener commandListener = new TestCommandListener();
-        // The failPoint only targets the failing command's name, and `skip` is the number of same-name commands
-        // preceding it, so those pass through and every subsequent matching command (i.e. the retries of the one
-        // command under test) is failed until its retries are exhausted.
-        String failCommandName = failingCommand.getFirstKey();
+        // The failPoint fails every command of the sequence, so `skip` is the number of commands preceding the
+        // failing one. It lets them pass through and then fails every subsequent one, so that all the retries of a
+        // single command in the sequence are exhausted.
         BsonDocument configureFailPoint = BsonDocument.parse(
                 "{\n"
                         + "    configureFailPoint: 'failCommand',\n"
                         + "    mode: {skip: " + failPointSkip + "},\n"
                         + "    data: {\n"
-                        + "        failCommands: ['" + failCommandName + "'],\n"
-                        + "        errorCode: 462,\n"
+                        + "        failCommands: ['create', 'createIndexes'],\n"
+                        + "        errorCode: " + SYSTEM_OVERLOAD_ERROR_CODE + ",\n"
                         + "        errorLabels: ['" + SYSTEM_OVERLOADED_ERROR_LABEL + "', '" + RETRYABLE_ERROR_LABEL + "']\n"
                         + "    }\n"
                         + "}\n");
@@ -720,7 +716,7 @@ public class BackpressureProseTest {
                 commandListener.reset();
                 MongoServerException e = assertThrows(MongoServerException.class, () -> database.createCollection(
                         NAMESPACE.getCollectionName(), encryptedCollectionOptions()));
-                assertEquals(462, e.getCode());
+                assertEquals(SYSTEM_OVERLOAD_ERROR_CODE, e.getCode());
                 assertCommandsStarted(expectedCommands, commandListener);
             }
         }
@@ -758,7 +754,7 @@ public class BackpressureProseTest {
                         + "    mode: {skip: " + failPointSkip + "},\n"
                         + "    data: {\n"
                         + "        failCommands: ['drop'],\n"
-                        + "        errorCode: 462,\n"
+                        + "        errorCode: " + SYSTEM_OVERLOAD_ERROR_CODE + ",\n"
                         + "        errorLabels: ['" + SYSTEM_OVERLOADED_ERROR_LABEL + "', '" + RETRYABLE_ERROR_LABEL + "']\n"
                         + "    }\n"
                         + "}\n");
@@ -769,13 +765,13 @@ public class BackpressureProseTest {
                 commandListener.reset();
                 MongoServerException e = assertThrows(MongoServerException.class, () -> getCollection(client).drop(
                         new DropCollectionOptions().encryptedFields(encryptedCollectionOptions().getEncryptedFields())));
-                assertEquals(462, e.getCode());
+                assertEquals(SYSTEM_OVERLOAD_ERROR_CODE, e.getCode());
                 assertCommandsStarted(expectedCommands, commandListener);
             }
         }
     }
 
-    private void assertCommandExhaustsOverloadRetriesAndThrows(final String commandName, final Consumer<MongoClient> operation)
+    private void assertCommandExhaustsOverloadRetriesAndThrows(final String failingCommandName, final Consumer<MongoClient> operation)
             throws InterruptedException {
         assumeTrue(serverVersionAtLeast(4, 4));
         TestCommandListener commandListener = new TestCommandListener();
@@ -784,8 +780,8 @@ public class BackpressureProseTest {
                 + "    configureFailPoint: 'failCommand',\n"
                 + "    mode: 'alwaysOn',\n"
                 + "    data: {\n"
-                + "        failCommands: ['" + commandName + "'],\n"
-                + "        errorCode: 462,\n"
+                + "        failCommands: ['" + failingCommandName + "'],\n"
+                + "        errorCode: " + SYSTEM_OVERLOAD_ERROR_CODE + ",\n"
                 + "        errorLabels: ['" + SYSTEM_OVERLOADED_ERROR_LABEL + "', '" + RETRYABLE_ERROR_LABEL + "']\n"
                 + "    }\n"
                 + "}\n");
@@ -794,25 +790,28 @@ public class BackpressureProseTest {
                 .build())) {
             try (FailPoint ignored = FailPoint.enable(configureFailPoint, getPrimary())) {
                 commandListener.reset();
-                assertThrows(MongoServerException.class, () -> operation.accept(client));
+                MongoServerException exception = assertThrows(MongoServerException.class, () -> operation.accept(client));
+                assertEquals(SYSTEM_OVERLOAD_ERROR_CODE, exception.getCode());
+                assertTrue(exception.hasErrorLabel(SYSTEM_OVERLOADED_ERROR_LABEL));
+                assertTrue(exception.hasErrorLabel(RETRYABLE_ERROR_LABEL));
                 assertEquals(DEFAULT_MAX_ADAPTIVE_RETRIES + 1,
-                        commandListener.getCommandStartedEvents(commandName).size(),
+                        commandListener.getCommandStartedEvents(failingCommandName).size(),
                         "Expected initial attempt plus " + DEFAULT_MAX_ADAPTIVE_RETRIES + " overload retries");
             }
         }
     }
 
-    private void assertCommandNotRetriedOnRetryableWriteError(final String commandName, final Consumer<MongoClient> operation)
+    private void assertCommandNotRetriedOnRetryableWriteError(final String failingCommandName, final Consumer<MongoClient> operation)
             throws InterruptedException {
-        assertCommandNotRetriedOnNonOverloadError(commandName, operation, RETRYABLE_WRITE_ERROR_LABEL);
+        assertCommandNotRetriedOnNonOverloadError(failingCommandName, operation, RETRYABLE_WRITE_ERROR_LABEL);
     }
 
-    private void assertCommandNotRetriedOnRetryableReadError(final String commandName, final Consumer<MongoClient> operation)
+    private void assertCommandNotRetriedOnRetryableReadError(final String failingCommandName, final Consumer<MongoClient> operation)
             throws InterruptedException {
-        assertCommandNotRetriedOnNonOverloadError(commandName, operation, null);
+        assertCommandNotRetriedOnNonOverloadError(failingCommandName, operation, null);
     }
 
-    private void assertCommandNotRetriedOnNonOverloadError(final String commandName, final Consumer<MongoClient> operation,
+    private void assertCommandNotRetriedOnNonOverloadError(final String failingCommandName, final Consumer<MongoClient> operation,
                                                            @Nullable final String errorLabel)
             throws InterruptedException {
         assumeTrue(serverVersionAtLeast(4, 4));
@@ -822,8 +821,8 @@ public class BackpressureProseTest {
                         + "    configureFailPoint: 'failCommand',\n"
                         + "    mode: {times: 1},\n"
                         + "    data: {\n"
-                        + "        failCommands: ['" + commandName + "'],\n"
-                        + "        errorCode: 11602,\n"
+                        + "        failCommands: ['" + failingCommandName + "'],\n"
+                        + "        errorCode: " + RETRYABLE_ERROR_CODE + ",\n"
                         + "        errorLabels: [" + (errorLabel == null ? "" : "'" + errorLabel + "'") + "]\n"
                         + "    }\n"
                         + "}\n");
@@ -833,30 +832,30 @@ public class BackpressureProseTest {
             try (FailPoint ignored = FailPoint.enable(configureFailPoint, getPrimary())) {
                 commandListener.reset();
                 MongoServerException exception = assertThrows(MongoServerException.class, () -> operation.accept(client));
-                assertEquals(11602, ((MongoCommandException) exception).getErrorCode(),
+                assertEquals(RETRYABLE_ERROR_CODE, ((MongoCommandException) exception).getErrorCode(),
                         format("Expected the propagated non-overload error, got: %s", exception));
                 if (errorLabel != null) {
                     assertTrue(exception.hasErrorLabel(errorLabel),
                             format("Expected the propagated error to have the %s label, got: %s", errorLabel, exception));
                 }
-                assertEquals(1, commandListener.getCommandStartedEvents(commandName).size(),
+                assertEquals(1, commandListener.getCommandStartedEvents(failingCommandName).size(),
                         format("Expected exactly one attempt of %s, as the overload-only policy does not retry"
-                                + " non-overload errors", commandName));
+                                + " non-overload errors", failingCommandName));
             }
         }
     }
 
-    private void assertCommandNotRetriedWhenRetryWritesDisabled(final String commandName, final Consumer<MongoClient> operation)
+    private void assertCommandNotRetriedWhenRetryWritesDisabled(final String failingCommandName, final Consumer<MongoClient> operation)
             throws InterruptedException {
-        assertCommandNotOverloadRetried(commandName, operation, true, false);
+        assertCommandNotOverloadRetried(failingCommandName, operation, true, false);
     }
 
-    private void assertCommandNotRetriedWhenRetryReadsDisabled(final String commandName, final Consumer<MongoClient> operation)
+    private void assertCommandNotRetriedWhenRetryReadsDisabled(final String failingCommandName, final Consumer<MongoClient> operation)
             throws InterruptedException {
-        assertCommandNotOverloadRetried(commandName, operation, false, true);
+        assertCommandNotOverloadRetried(failingCommandName, operation, false, true);
     }
 
-    private void assertCommandNotOverloadRetried(final String commandName, final Consumer<MongoClient> operation,
+    private void assertCommandNotOverloadRetried(final String failingCommandName, final Consumer<MongoClient> operation,
                                          final boolean retryReads, final boolean retryWrites)
             throws InterruptedException {
         assumeTrue(serverVersionAtLeast(4, 4));
@@ -866,8 +865,8 @@ public class BackpressureProseTest {
                         + "    configureFailPoint: 'failCommand',\n"
                         + "    mode: 'alwaysOn',\n"
                         + "    data: {\n"
-                        + "        failCommands: ['" + commandName + "'],\n"
-                        + "        errorCode: 462,\n"
+                        + "        failCommands: ['" + failingCommandName + "'],\n"
+                        + "        errorCode: " + SYSTEM_OVERLOAD_ERROR_CODE + ",\n"
                         + "        errorLabels: ['" + SYSTEM_OVERLOADED_ERROR_LABEL + "', '" + RETRYABLE_ERROR_LABEL + "']\n"
                         + "    }\n"
                         + "}\n");
@@ -879,11 +878,13 @@ public class BackpressureProseTest {
             try (FailPoint ignored = FailPoint.enable(configureFailPoint, getPrimary())) {
                 commandListener.reset();
                 MongoServerException exception = assertThrows(MongoServerException.class, () -> operation.accept(client));
+                assertEquals(SYSTEM_OVERLOAD_ERROR_CODE, exception.getCode());
                 assertTrue(exception.hasErrorLabel(SYSTEM_OVERLOADED_ERROR_LABEL),
                         "Expected propagated overload error, got: " + exception);
-                assertEquals(1, commandListener.getCommandStartedEvents(commandName).size(),
+                assertTrue(exception.hasErrorLabel(RETRYABLE_ERROR_LABEL));
+                assertEquals(1, commandListener.getCommandStartedEvents(failingCommandName).size(),
                         format("Expected exactly one attempt of %s, as retryReads=%b, retryWrites=%b disable the"
-                                + " overload retry", commandName, retryReads, retryWrites));
+                                + " overload retry", failingCommandName, retryReads, retryWrites));
             }
         }
     }

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -20,11 +20,9 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.MongoServerException;
-import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.DropCollectionOptions;
 import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Indexes;
 import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.Updates;
 import com.mongodb.client.model.bulk.ClientBulkWriteResult;
@@ -63,6 +61,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.nCopies;
 import static java.util.Collections.singletonList;
 
+import static com.mongodb.ClusterFixture.isStandalone;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.MongoException.RETRYABLE_ERROR_LABEL;
 import static com.mongodb.MongoException.SYSTEM_OVERLOADED_ERROR_LABEL;
@@ -76,6 +75,7 @@ import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
@@ -696,6 +696,7 @@ public class BackpressureProseTest {
             final int failPointSkip,
             final List<BsonDocument> expectedCommands) throws InterruptedException {
         assumeTrue(serverVersionAtLeast(7, 0));
+        assumeFalse(isStandalone(), "Encrypted collections are not supported on standalone");
         TestCommandListener commandListener = new TestCommandListener();
         // The failPoint only targets the failing command's name, and `skip` is the number of same-name commands
         // preceding it, so those pass through and every subsequent matching command (i.e. the retries of the one
@@ -746,6 +747,7 @@ public class BackpressureProseTest {
             final int failPointSkip,
             final List<BsonDocument> expectedCommands) throws InterruptedException {
         assumeTrue(serverVersionAtLeast(7, 0));
+        assumeFalse(isStandalone(), "Encrypted collections are not supported on standalone");
         TestCommandListener commandListener = new TestCommandListener();
         // The failPoint fails every command of the sequence, so `skip` is the number of the commands preceding the
         // failing one. It lets them pass through and then fails every subsequent one, so that all the retries of a

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -502,7 +502,6 @@ public class BackpressureProseTest {
     @Test
     void createSearchIndexesExhaustsOverloadRetriesAndThrows() throws InterruptedException {
         assumeTrue(serverVersionAtLeast(6, 0));
-        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
         assertCommandExhaustsOverloadRetriesAndThrows("createSearchIndexes",
                 client -> getCollection(client).createSearchIndexes(
                         singletonList(new SearchIndexModel(new Document("mappings", new Document("dynamic", true))))));
@@ -511,7 +510,6 @@ public class BackpressureProseTest {
     @Test
     void updateSearchIndexExhaustsOverloadRetriesAndThrows() throws InterruptedException {
         assumeTrue(serverVersionAtLeast(6, 0));
-        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
         assertCommandExhaustsOverloadRetriesAndThrows("updateSearchIndex",
                 client -> getCollection(client).updateSearchIndex("default", new Document("mappings", new Document("dynamic", true))));
     }
@@ -519,7 +517,6 @@ public class BackpressureProseTest {
     @Test
     void dropSearchIndexExhaustsOverloadRetriesAndThrows() throws InterruptedException {
         assumeTrue(serverVersionAtLeast(6, 0));
-        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
         assertCommandExhaustsOverloadRetriesAndThrows("dropSearchIndex",
                 client -> getCollection(client).dropSearchIndex("default"));
     }
@@ -578,7 +575,7 @@ public class BackpressureProseTest {
     @Test
     void createSearchIndexesDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
         assumeTrue(serverVersionAtLeast(6, 0));
-        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+
         assertCommandNotRetriedWhenRetryWritesDisabled("createSearchIndexes",
                 client -> getCollection(client).createSearchIndexes(
                         singletonList(new SearchIndexModel(new Document("mappings", new Document("dynamic", true))))));
@@ -587,7 +584,7 @@ public class BackpressureProseTest {
     @Test
     void updateSearchIndexDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
         assumeTrue(serverVersionAtLeast(6, 0));
-        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+
         assertCommandNotRetriedWhenRetryWritesDisabled("updateSearchIndex",
                 client -> getCollection(client).updateSearchIndex("default", new Document("mappings", new Document("dynamic", true))));
     }
@@ -595,7 +592,7 @@ public class BackpressureProseTest {
     @Test
     void dropSearchIndexDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
         assumeTrue(serverVersionAtLeast(6, 0));
-        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+
         assertCommandNotRetriedWhenRetryWritesDisabled("dropSearchIndex",
                 client -> getCollection(client).dropSearchIndex("default"));
     }
@@ -647,7 +644,7 @@ public class BackpressureProseTest {
     @Test
     void createSearchIndexesDoesNotRetryOnRetryableWriteError() throws InterruptedException {
         assumeTrue(serverVersionAtLeast(6, 0));
-        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+
         assertCommandNotRetriedOnRetryableWriteError("createSearchIndexes",
                 client -> getCollection(client).createSearchIndexes(
                         singletonList(new SearchIndexModel(new Document("mappings", new Document("dynamic", true))))));
@@ -656,7 +653,7 @@ public class BackpressureProseTest {
     @Test
     void updateSearchIndexDoesNotRetryOnRetryableWriteError() throws InterruptedException {
         assumeTrue(serverVersionAtLeast(6, 0));
-        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+
         assertCommandNotRetriedOnRetryableWriteError("updateSearchIndex",
                 client -> getCollection(client).updateSearchIndex("default", new Document("mappings", new Document("dynamic", true))));
     }
@@ -664,7 +661,7 @@ public class BackpressureProseTest {
     @Test
     void dropSearchIndexDoesNotRetryOnRetryableWriteError() throws InterruptedException {
         assumeTrue(serverVersionAtLeast(6, 0));
-        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+       // assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
         assertCommandNotRetriedOnRetryableWriteError("dropSearchIndex",
                 client -> getCollection(client).dropSearchIndex("default"));
     }
@@ -887,10 +884,6 @@ public class BackpressureProseTest {
                                 + " overload retry", failingCommandName, retryReads, retryWrites));
             }
         }
-    }
-
-    private static boolean hasAtlasSearchIndexHelperEnabled() {
-        return Boolean.parseBoolean(System.getProperty("org.mongodb.test.atlas.search.index.helpers"));
     }
 
     private static MongoCollection<Document> dropAndGetCollection(final String name, final MongoClient client) {

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -53,7 +53,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.mongodb.client.model.Aggregates.match;
-import static com.mongodb.client.model.Indexes.ascending;
 import static com.mongodb.client.model.bulk.ClientBulkWriteOptions.clientBulkWriteOptions;
 import static com.mongodb.client.model.bulk.ClientUpdateOneOptions.clientUpdateOneOptions;
 import static java.lang.String.join;
@@ -462,18 +461,6 @@ public class BackpressureProseTest {
     }
 
     @Test
-    void createIndexesExhaustsOverloadRetriesAndThrows() throws InterruptedException {
-        assertCommandExhaustsOverloadRetriesAndThrows("createIndexes",
-                client -> getCollection(client).createIndex(ascending("a")));
-    }
-
-    @Test
-    void dropIndexExhaustsOverloadRetriesAndThrows() throws InterruptedException {
-        assertCommandExhaustsOverloadRetriesAndThrows("dropIndexes",
-                client -> getCollection(client).dropIndex(ascending("a")));
-    }
-
-    @Test
     void createViewExhaustsOverloadRetriesAndThrows() throws InterruptedException {
         assertCommandExhaustsOverloadRetriesAndThrows("create",
                 client -> client.getDatabase(NAMESPACE.getDatabaseName())
@@ -527,18 +514,6 @@ public class BackpressureProseTest {
                 client -> client.getDatabase(NAMESPACE.getDatabaseName()).createCollection(NAMESPACE.getCollectionName()));
     }
 
-
-    @Test
-    void createIndexesDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
-        assertCommandNotRetriedWhenRetryWritesDisabled("createIndexes",
-                client -> getCollection(client).createIndex(ascending("a")));
-    }
-
-    @Test
-    void dropIndexDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
-        assertCommandNotRetriedWhenRetryWritesDisabled("dropIndexes",
-                client -> getCollection(client).dropIndex(ascending("a")));
-    }
 
     @Test
     void createViewDoesNotRetryOverloadWhenRetryWritesDisabled() throws InterruptedException {
@@ -595,18 +570,6 @@ public class BackpressureProseTest {
 
         assertCommandNotRetriedWhenRetryWritesDisabled("dropSearchIndex",
                 client -> getCollection(client).dropSearchIndex("default"));
-    }
-
-    @Test
-    void createIndexesDoesNotRetryOnRetryableWriteError() throws InterruptedException {
-        assertCommandNotRetriedOnRetryableWriteError("createIndexes",
-                client -> getCollection(client).createIndex(ascending("a")));
-    }
-
-    @Test
-    void dropIndexDoesNotRetryOnRetryableWriteError() throws InterruptedException {
-        assertCommandNotRetriedOnRetryableWriteError("dropIndexes",
-                client -> getCollection(client).dropIndex(ascending("a")));
     }
 
     @Test

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -21,6 +21,7 @@ import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.MongoServerException;
 import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.Updates;
 import com.mongodb.client.model.bulk.ClientBulkWriteResult;
 import com.mongodb.client.model.bulk.ClientNamespacedWriteModel;
@@ -38,12 +39,14 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 
 import static com.mongodb.client.model.bulk.ClientBulkWriteOptions.clientBulkWriteOptions;
 import static com.mongodb.client.model.bulk.ClientUpdateOneOptions.clientUpdateOneOptions;
 import static java.lang.String.join;
 import static java.util.Arrays.asList;
 import static java.util.Collections.nCopies;
+import static java.util.Collections.singletonList;
 
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.MongoException.RETRYABLE_ERROR_LABEL;
@@ -502,6 +505,146 @@ public class BackpressureProseTest {
                         Updates.set("x", 1),
                         clientUpdateOneOptions().upsert(true)));
         return client.bulkWrite(models, clientBulkWriteOptions().verboseResults(true));
+    }
+
+    /**
+     * Asserts that the supplied write command is overload-retried the expected number of times.
+     *
+     * @param commandName the server command name to fail with an overload error
+     * @param setUp       an optional setup invoked before the fail point is enabled (e.g. creating a collection)
+     * @param operation   the operation under test, invoked with the client
+     */
+    private void assertWriteCommandOverloadRetried(final String commandName, final Consumer<MongoClient> setUp,
+            final Consumer<MongoClient> operation) throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(4, 4));
+        TestCommandListener commandListener = new TestCommandListener();
+        BsonDocument configureFailPoint = BsonDocument.parse(
+                "{\n"
+                + "    configureFailPoint: 'failCommand',\n"
+                + "    mode: 'alwaysOn',\n"
+                + "    data: {\n"
+                + "        failCommands: ['" + commandName + "'],\n"
+                + "        errorCode: 462,\n"
+                + "        errorLabels: ['" + SYSTEM_OVERLOADED_ERROR_LABEL + "', '" + RETRYABLE_ERROR_LABEL + "']\n"
+                + "    }\n"
+                + "}\n");
+        try (MongoClient client = createClient(MongoClientSettings.builder(getMongoClientSettings())
+                .addCommandListener(commandListener)
+                .build())) {
+            setUp.accept(client);
+            try (FailPoint ignored = FailPoint.enable(configureFailPoint, getPrimary())) {
+                commandListener.reset();
+                assertThrows(MongoServerException.class, () -> operation.accept(client));
+                assertEquals(DEFAULT_MAX_ADAPTIVE_RETRIES + 1,
+                        commandListener.getCommandStartedEvents(commandName).size(),
+                        "Expected initial attempt plus " + DEFAULT_MAX_ADAPTIVE_RETRIES + " overload retries");
+            }
+        }
+    }
+
+    @Test
+    void createIndexesOverloadRetries() throws InterruptedException {
+        assertWriteCommandOverloadRetried("createIndexes",
+                client -> dropAndGetCollection("createIndexesOverloadRetries", client),
+                client -> client.getDatabase(getDefaultDatabaseName()).getCollection("createIndexesOverloadRetries")
+                        .createIndex(new Document("a", 1)));
+    }
+
+    @Test
+    void dropIndexOverloadRetries() throws InterruptedException {
+        assertWriteCommandOverloadRetried("dropIndexes",
+                client -> {
+                    MongoCollection<Document> coll = dropAndGetCollection("dropIndexOverloadRetries", client);
+                    coll.createIndex(new Document("a", 1));
+                },
+                client -> client.getDatabase(getDefaultDatabaseName()).getCollection("dropIndexOverloadRetries")
+                        .dropIndex(new Document("a", 1)));
+    }
+
+    @Test
+    void createCollectionOverloadRetries() throws InterruptedException {
+        assertWriteCommandOverloadRetried("create",
+                client -> client.getDatabase(getDefaultDatabaseName()).getCollection("createCollectionOverloadRetries").drop(),
+                client -> client.getDatabase(getDefaultDatabaseName()).createCollection("createCollectionOverloadRetries"));
+    }
+
+    @Test
+    void createViewOverloadRetries() throws InterruptedException {
+        assertWriteCommandOverloadRetried("create",
+                client -> {
+                    MongoCollection<Document> source = dropAndGetCollection("createViewOverloadRetriesSource", client);
+                    source.insertOne(new Document());
+                },
+                client -> client.getDatabase(getDefaultDatabaseName())
+                        .createView("createViewOverloadRetries", "createViewOverloadRetriesSource",
+                                asList(new Document("$match", new Document()))));
+    }
+
+    @Test
+    void dropCollectionOverloadRetries() throws InterruptedException {
+        assertWriteCommandOverloadRetried("drop",
+                client -> dropAndGetCollection("dropCollectionOverloadRetries", client),
+                client -> client.getDatabase(getDefaultDatabaseName()).getCollection("dropCollectionOverloadRetries").drop());
+    }
+
+    @Test
+    void dropDatabaseOverloadRetries() throws InterruptedException {
+        assertWriteCommandOverloadRetried("dropDatabase",
+                client -> {
+                    // no setup required
+                },
+                client -> client.getDatabase(getDefaultDatabaseName()).drop());
+    }
+
+    @Test
+    void renameCollectionOverloadRetries() throws InterruptedException {
+        assertWriteCommandOverloadRetried("renameCollection",
+                client -> dropAndGetCollection("renameCollectionOverloadRetriesSource", client),
+                client -> {
+                    MongoDatabase database = client.getDatabase(getDefaultDatabaseName());
+                    database.getCollection("renameCollectionOverloadRetriesSource")
+                            .renameCollection(new MongoNamespace(getDefaultDatabaseName(), "renameCollectionOverloadRetries"));
+                });
+    }
+
+    @Test
+    void createSearchIndexesOverloadRetries() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(6, 0));
+        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+        assertWriteCommandOverloadRetried("createSearchIndexes",
+                client -> dropAndGetCollection("createSearchIndexesOverloadRetries", client),
+                client -> client.getDatabase(getDefaultDatabaseName()).getCollection("createSearchIndexesOverloadRetries")
+                        .createSearchIndexes(singletonList(new SearchIndexModel(new Document("mappings", new Document("dynamic", true))))));
+    }
+
+    @Test
+    void updateSearchIndexOverloadRetries() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(6, 0));
+        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+        assertWriteCommandOverloadRetried("updateSearchIndex",
+                client -> {
+                    MongoCollection<Document> coll = dropAndGetCollection("updateSearchIndexOverloadRetries", client);
+                    coll.createSearchIndex(new Document("mappings", new Document("dynamic", true)));
+                },
+                client -> client.getDatabase(getDefaultDatabaseName()).getCollection("updateSearchIndexOverloadRetries")
+                        .updateSearchIndex("default", new Document("mappings", new Document("dynamic", true))));
+    }
+
+    @Test
+    void dropSearchIndexOverloadRetries() throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(6, 0));
+        assumeTrue(hasAtlasSearchIndexHelperEnabled(), "Atlas Search Index tests are disabled");
+        assertWriteCommandOverloadRetried("dropSearchIndex",
+                client -> {
+                    MongoCollection<Document> coll = dropAndGetCollection("dropSearchIndexOverloadRetries", client);
+                    coll.createSearchIndex(new Document("mappings", new Document("dynamic", true)));
+                },
+                client -> client.getDatabase(getDefaultDatabaseName()).getCollection("dropSearchIndexOverloadRetries")
+                        .dropSearchIndex("default"));
+    }
+
+    private static boolean hasAtlasSearchIndexHelperEnabled() {
+        return Boolean.parseBoolean(System.getProperty("org.mongodb.test.atlas.search.index.helpers"));
     }
 
     private static MongoCollection<Document> dropAndGetCollection(final String name, final MongoClient client) {

--- a/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/BackpressureProseTest.java
@@ -21,6 +21,7 @@ import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.MongoServerException;
 import com.mongodb.client.model.CreateCollectionOptions;
+import com.mongodb.client.model.DropCollectionOptions;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.Updates;
@@ -706,6 +707,54 @@ public class BackpressureProseTest {
                 commandListener.reset();
                 MongoServerException e = assertThrows(MongoServerException.class, () -> database.createCollection(
                         NAMESPACE.getCollectionName(), encryptedCollectionOptions()));
+                assertEquals(462, e.getCode());
+                assertCommandsStarted(expectedCommands, commandListener);
+            }
+        }
+    }
+
+    private static Stream<Arguments> dropEncryptedCollectionRetriesEachCommandIndependently() {
+        String collectionName = NAMESPACE.getCollectionName();
+        List<BsonDocument> commandSequence = asList(
+                new BsonDocument("drop", new BsonString(ENCRYPTED_STATE_COLLECTION_PREFIX + collectionName + ".esc")),
+                new BsonDocument("drop", new BsonString(ENCRYPTED_STATE_COLLECTION_PREFIX + collectionName + ".ecoc")),
+                new BsonDocument("drop", new BsonString(collectionName)));
+        return IntStream.range(0, commandSequence.size()).mapToObj(failingCommandIndex -> {
+            BsonDocument failingCommand = commandSequence.get(failingCommandIndex);
+            List<BsonDocument> expectedCommands = new ArrayList<>(commandSequence.subList(0, failingCommandIndex));
+            expectedCommands.addAll(nCopies(DEFAULT_MAX_ADAPTIVE_RETRIES + 1, failingCommand));
+            return Arguments.of(failingCommand, failingCommandIndex, expectedCommands);
+        });
+    }
+
+    @ParameterizedTest(name = "dropEncryptedCollectionRetriesEachCommandIndependently. failingCommand={0}, failPointSkip=={1}")
+    @MethodSource
+    void dropEncryptedCollectionRetriesEachCommandIndependently(
+            final BsonDocument failingCommand,
+            final int failPointSkip,
+            final List<BsonDocument> expectedCommands) throws InterruptedException {
+        assumeTrue(serverVersionAtLeast(7, 0));
+        TestCommandListener commandListener = new TestCommandListener();
+        // The failPoint fails every command of the sequence, so `skip` is the number of the commands preceding the
+        // failing one. It lets them pass through and then fails every subsequent one, so that all the retries of a
+        // single command in the sequence are exhausted.
+        BsonDocument configureFailPoint = BsonDocument.parse(
+                "{\n"
+                        + "    configureFailPoint: 'failCommand',\n"
+                        + "    mode: {skip: " + failPointSkip + "},\n"
+                        + "    data: {\n"
+                        + "        failCommands: ['drop'],\n"
+                        + "        errorCode: 462,\n"
+                        + "        errorLabels: ['" + SYSTEM_OVERLOADED_ERROR_LABEL + "', '" + RETRYABLE_ERROR_LABEL + "']\n"
+                        + "    }\n"
+                        + "}\n");
+        try (MongoClient client = createClient(MongoClientSettings.builder(getMongoClientSettings())
+                .addCommandListener(commandListener)
+                .build())) {
+            try (FailPoint ignored = FailPoint.enable(configureFailPoint, getPrimary())) {
+                commandListener.reset();
+                MongoServerException e = assertThrows(MongoServerException.class, () -> getCollection(client).drop(
+                        new DropCollectionOptions().encryptedFields(encryptedCollectionOptions().getEncryptedFields())));
                 assertEquals(462, e.getCode());
                 assertCommandsStarted(expectedCommands, commandListener);
             }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -596,24 +596,6 @@ public final class UnifiedTestModifications {
                 .test("client-backpressure", "tests that operations respect overload backoff retry loop",
                         "collection.createChangeStream (read) does not retry if retryReads=false");
 
-        // TODO-BACKPRESSURE enable the below tests when JAVA-5956 is done
-        def.skipJira("https://jira.mongodb.org/browse/JAVA-5956 TODO-JAVA-5956")
-                .test("client-backpressure", "tests that operations respect overload backoff retry loop", "collection.createIndex retries using operation loop");
-        def.skipJira("https://jira.mongodb.org/browse/JAVA-5956 TODO-JAVA-5956")
-                .test("client-backpressure", "tests that operations respect overload backoff retry loop", "collection.dropIndex retries using operation loop");
-        def.skipJira("https://jira.mongodb.org/browse/JAVA-5956 TODO-JAVA-5956")
-                .test("client-backpressure", "tests that operations respect overload backoff retry loop", "collection.dropIndexes retries using operation loop");
-        def.skipJira("https://jira.mongodb.org/browse/JAVA-5956 TODO-JAVA-5956")
-                .test("client-backpressure", "tests that operations respect overload backoff retry loop", "collection.aggregate write retries using operation loop");
-        def.skipJira("https://jira.mongodb.org/browse/JAVA-5956 TODO-JAVA-5956")
-                .test("client-backpressure", "tests that operations retry at most maxAttempts=2 times", "collection.createIndex retries at most maxAttempts=2 times");
-        def.skipJira("https://jira.mongodb.org/browse/JAVA-5956 TODO-JAVA-5956")
-                .test("client-backpressure", "tests that operations retry at most maxAttempts=2 times", "collection.dropIndex retries at most maxAttempts=2 times");
-        def.skipJira("https://jira.mongodb.org/browse/JAVA-5956 TODO-JAVA-5956")
-                .test("client-backpressure", "tests that operations retry at most maxAttempts=2 times", "collection.dropIndexes retries at most maxAttempts=2 times");
-        def.skipJira("https://jira.mongodb.org/browse/JAVA-5956 TODO-JAVA-5956")
-                .test("client-backpressure", "tests that operations retry at most maxAttempts=2 times", "collection.aggregate write retries at most maxAttempts=2 times");
-
         // BatchCursorFlux fires closeCursor() then sink.error(e) without awaiting the killCursors reply,
         // so under reactive the test framework snapshots command events before killCursors succeeded lands.
         // Equivalent coverage is provided by the reactive BackpressureProseTest.

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -576,7 +576,7 @@ public final class UnifiedTestModifications {
 
         // backpressure
 
-        def.modify(WAIT_FOR_BATCH_CURSOR_CREATION)
+        def.modify(WAIT_FOR_BATCH_CURSOR_CREATION, IGNORE_EXTRA_EVENTS)
                 .test("client-backpressure", "tests that operations retry at most maxAttempts=2 times",
                         "client.createChangeStream retries at most maxAttempts=2 times")
                 .test("client-backpressure", "tests that operations retry at most maxAttempts=2 times",

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/AggregateIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/AggregateIterableSpecification.groovy
@@ -63,7 +63,7 @@ class AggregateIterableSpecification extends Specification {
         def pipeline = [new Document('$match', 1)]
         def aggregationIterable = new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
                 readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION,
-                true, null, TIMEOUT_SETTINGS)
+                false, true, null, TIMEOUT_SETTINGS)
 
         when: 'default input should be as expected'
         aggregationIterable.iterator()
@@ -98,7 +98,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'both hint and hint string are set'
         aggregationIterable = new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
 
         aggregationIterable
                 .hint(new Document('a', 1))
@@ -122,7 +122,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'aggregation includes $out'
         new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, writeConcern, executor,
-                pipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                pipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
                 .batchSize(99)
                 .allowDiskUse(true)
                 .collation(collation)
@@ -152,7 +152,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'aggregation includes $out and is at the database level'
         new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, writeConcern, executor,
-                pipeline, AggregationLevel.DATABASE, false, null, TIMEOUT_SETTINGS)
+                pipeline, AggregationLevel.DATABASE, false, false, null, TIMEOUT_SETTINGS)
                 .batchSize(99)
                 .maxTime(100, MILLISECONDS)
                 .allowDiskUse(true)
@@ -185,7 +185,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'toCollection should work as expected'
         new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, writeConcern, executor,
-                pipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                pipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
                 .allowDiskUse(true)
                 .collation(collation)
                 .hint(new Document('a', 1))
@@ -212,7 +212,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'aggregation includes $out and hint string'
         new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, writeConcern, executor,
-                pipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                pipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
                 .hintString('x_1').iterator()
 
         def operation = executor.getReadOperation() as AggregateToCollectionOperation
@@ -226,7 +226,7 @@ class AggregateIterableSpecification extends Specification {
         when: 'aggregation includes $out and hint and hint string'
         executor = new TestOperationExecutor([null, null, null, null, null])
         new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, writeConcern, executor,
-                pipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                pipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
                 .hint(new BsonDocument('x', new BsonInt32(1)))
                 .hintString('x_1').iterator()
 
@@ -250,7 +250,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'aggregation includes $merge'
         new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, writeConcern, executor,
-                pipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                pipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
                 .batchSize(99)
                 .allowDiskUse(true)
                 .collation(collation)
@@ -281,7 +281,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'aggregation includes $merge into a different database'
         new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, writeConcern, executor,
-                pipelineWithIntoDocument, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                pipelineWithIntoDocument, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
                 .batchSize(99)
                 .maxTime(100, MILLISECONDS)
                 .allowDiskUse(true)
@@ -314,7 +314,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'aggregation includes $merge and is at the database level'
         new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, writeConcern, executor,
-                pipeline, AggregationLevel.DATABASE, false, null, TIMEOUT_SETTINGS)
+                pipeline, AggregationLevel.DATABASE, false, false, null, TIMEOUT_SETTINGS)
                 .batchSize(99)
                 .maxTime(100, MILLISECONDS)
                 .allowDiskUse(true)
@@ -346,7 +346,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'toCollection should work as expected'
         new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, writeConcern, executor,
-                pipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                pipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
                 .allowDiskUse(true)
                 .collation(collation)
                 .hint(new Document('a', 1))
@@ -375,7 +375,7 @@ class AggregateIterableSpecification extends Specification {
 
         when:
         new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, writeConcern, executor,
-                pipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                pipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
                 .iterator()
 
         def operation = executor.getReadOperation() as AggregateToCollectionOperation
@@ -419,7 +419,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'aggregation includes $out'
         def aggregateIterable = new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
 
         aggregateIterable.toCollection()
         def operation = executor.getReadOperation() as AggregateToCollectionOperation
@@ -438,7 +438,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'aggregation includes $out and is at the database level'
         aggregateIterable = new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, pipeline, AggregationLevel.DATABASE, false, null, TIMEOUT_SETTINGS)
+                readConcern, writeConcern, executor, pipeline, AggregationLevel.DATABASE, false, false, null, TIMEOUT_SETTINGS)
         aggregateIterable.toCollection()
 
         operation = executor.getReadOperation() as AggregateToCollectionOperation
@@ -457,7 +457,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'toCollection should work as expected'
         aggregateIterable = new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
         aggregateIterable.toCollection()
 
         operation = executor.getReadOperation() as AggregateToCollectionOperation
@@ -475,7 +475,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'aggregation includes $out with namespace'
         aggregateIterable = new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, outWithDBpipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                readConcern, writeConcern, executor, outWithDBpipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
         aggregateIterable.toCollection()
 
         operation = executor.getReadOperation() as AggregateToCollectionOperation
@@ -502,7 +502,7 @@ class AggregateIterableSpecification extends Specification {
         def executor = new TestOperationExecutor([batchCursor, batchCursor])
         def pipeline = [new Document('$match', 1)]
         def aggregationIterable = new AggregateIterableImpl(clientSession, namespace, Document, Document, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
 
         when:
         aggregationIterable.first()
@@ -528,7 +528,7 @@ class AggregateIterableSpecification extends Specification {
         def executor = new TestOperationExecutor([null, batchCursor, null, batchCursor, null])
         def pipeline = [new Document('$match', 1), new Document('$out', 'collName')]
         def aggregationIterable = new AggregateIterableImpl(clientSession, namespace, Document, Document, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
 
         when:
         aggregationIterable.first()
@@ -559,7 +559,7 @@ class AggregateIterableSpecification extends Specification {
         def executor = new TestOperationExecutor([new MongoException('failure')])
         def pipeline = [new BsonDocument('$match', new BsonInt32(1))]
         def aggregationIterable = new AggregateIterableImpl(null, namespace, BsonDocument, BsonDocument, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS)
+                readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS)
 
         when: 'The operation fails with an exception'
         aggregationIterable.iterator()
@@ -575,14 +575,14 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'a codec is missing'
         new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, writeConcern, executor,
-                pipeline, AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS).iterator()
+                pipeline, AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS).iterator()
 
         then:
         thrown(CodecConfigurationException)
 
         when: 'pipeline contains null'
         new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, writeConcern, executor,
-                [null], AggregationLevel.COLLECTION, false, null, TIMEOUT_SETTINGS).iterator()
+                [null], AggregationLevel.COLLECTION, false, false, null, TIMEOUT_SETTINGS).iterator()
 
         then:
         thrown(IllegalArgumentException)
@@ -611,7 +611,7 @@ class AggregateIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()])
         def mongoIterable = new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, [new Document('$match', 1)], AggregationLevel.COLLECTION, false, null,
+                readConcern, writeConcern, executor, [new Document('$match', 1)], AggregationLevel.COLLECTION, false, false, null,
                 TIMEOUT_SETTINGS)
 
         when:
@@ -657,7 +657,7 @@ class AggregateIterableSpecification extends Specification {
         def batchSize = 5
         def mongoIterable = new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
                 readConcern, writeConcern, Stub(OperationExecutor), [new Document('$match', 1)], AggregationLevel.COLLECTION,
-                false, null, TIMEOUT_SETTINGS)
+                false, false, null, TIMEOUT_SETTINGS)
 
         then:
         mongoIterable.getBatchSize() == null

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
@@ -376,7 +376,7 @@ class MongoCollectionSpecification extends Specification {
         then:
         expect aggregateIterable, isTheSameAs(new AggregateIterableImpl<>(session, namespace, Document, Document,
                 codecRegistry, readPreference, readConcern, ACKNOWLEDGED, executor, [new Document('$match', 1)],
-                AggregationLevel.COLLECTION, true, null, TIMEOUT_SETTINGS))
+                AggregationLevel.COLLECTION, true, true, null, TIMEOUT_SETTINGS))
 
         when:
         aggregateIterable = execute(aggregateMethod, session, [new Document('$match', 1)], BsonDocument)
@@ -384,7 +384,7 @@ class MongoCollectionSpecification extends Specification {
         then:
         expect aggregateIterable, isTheSameAs(new AggregateIterableImpl<>(session, namespace, Document, BsonDocument,
                 codecRegistry, readPreference, readConcern, ACKNOWLEDGED, executor, [new Document('$match', 1)],
-                AggregationLevel.COLLECTION, true, null, TIMEOUT_SETTINGS))
+                AggregationLevel.COLLECTION, true, true, null, TIMEOUT_SETTINGS))
 
         where:
         session << [null, Stub(ClientSession)]
@@ -1149,7 +1149,7 @@ class MongoCollectionSpecification extends Specification {
         def executor = new TestOperationExecutor([null])
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, ACKNOWLEDGED,
                 true, true, null, readConcern, JAVA_LEGACY, null, TIMEOUT_SETTINGS, executor)
-        def expectedOperation = new DropCollectionOperation(namespace, ACKNOWLEDGED)
+        def expectedOperation = new DropCollectionOperation(namespace, ACKNOWLEDGED, true, null)
         def dropMethod = collection.&drop
 
         when:
@@ -1174,7 +1174,7 @@ class MongoCollectionSpecification extends Specification {
 
         when:
         def expectedOperation = new CreateIndexesOperation(namespace,
-                [new IndexRequest(new BsonDocument('key', new BsonInt32(1)))], ACKNOWLEDGED)
+                [new IndexRequest(new BsonDocument('key', new BsonInt32(1)))], ACKNOWLEDGED, true, null)
         def indexName = execute(createIndexMethod, session, new Document('key', 1))
         def operation = executor.getWriteOperation() as CreateIndexesOperation
 
@@ -1185,7 +1185,7 @@ class MongoCollectionSpecification extends Specification {
         when:
         expectedOperation = new CreateIndexesOperation(namespace,
                 [new IndexRequest(new BsonDocument('key', new BsonInt32(1))),
-                 new IndexRequest(new BsonDocument('key1', new BsonInt32(1)))], ACKNOWLEDGED)
+                 new IndexRequest(new BsonDocument('key1', new BsonInt32(1)))], ACKNOWLEDGED, true, null)
         def indexNames = execute(createIndexesMethod, session, [new IndexModel(new Document('key', 1)),
                                                                                        new IndexModel(new Document('key1', 1))])
         operation = executor.getWriteOperation() as CreateIndexesOperation
@@ -1198,7 +1198,7 @@ class MongoCollectionSpecification extends Specification {
         when:
         expectedOperation = new CreateIndexesOperation(namespace,
                 [new IndexRequest(new BsonDocument('key', new BsonInt32(1))),
-                 new IndexRequest(new BsonDocument('key1', new BsonInt32(1)))], ACKNOWLEDGED)
+                 new IndexRequest(new BsonDocument('key1', new BsonInt32(1)))], ACKNOWLEDGED, true, null)
         indexNames = execute(createIndexesMethod, session,
                 [new IndexModel(new Document('key', 1)), new IndexModel(new Document('key1', 1))],
                 new CreateIndexOptions().maxTime(100, MILLISECONDS))
@@ -1212,7 +1212,7 @@ class MongoCollectionSpecification extends Specification {
         when:
         expectedOperation = new CreateIndexesOperation(namespace,
                 [new IndexRequest(new BsonDocument('key', new BsonInt32(1))),
-                 new IndexRequest(new BsonDocument('key1', new BsonInt32(1)))], ACKNOWLEDGED)
+                 new IndexRequest(new BsonDocument('key1', new BsonInt32(1)))], ACKNOWLEDGED, true, null)
                 .commitQuorum(CreateIndexCommitQuorum.VOTING_MEMBERS)
         indexNames = execute(createIndexesMethod, session,
                 [new IndexModel(new Document('key', 1)), new IndexModel(new Document('key1', 1))],
@@ -1246,7 +1246,7 @@ class MongoCollectionSpecification extends Specification {
                          .collation(collation)
                          .wildcardProjection(new BsonDocument('a', new BsonInt32(1)))
                          .hidden(true)
-                ], ACKNOWLEDGED)
+                ], ACKNOWLEDGED, true, null)
         indexName = execute(createIndexMethod, session, new Document('key', 1), new IndexOptions()
                 .background(true)
                 .unique(true)
@@ -1342,7 +1342,7 @@ class MongoCollectionSpecification extends Specification {
         def dropIndexMethod = collection.&dropIndex
 
         when:
-        def expectedOperation = new DropIndexOperation(namespace, 'indexName', ACKNOWLEDGED)
+        def expectedOperation = new DropIndexOperation(namespace, 'indexName', ACKNOWLEDGED, true, null)
         execute(dropIndexMethod, session, 'indexName')
         def operation = executor.getWriteOperation() as DropIndexOperation
 
@@ -1352,7 +1352,7 @@ class MongoCollectionSpecification extends Specification {
 
         when:
         def keys = new BsonDocument('x', new BsonInt32(1))
-        expectedOperation = new DropIndexOperation(namespace, keys, ACKNOWLEDGED)
+        expectedOperation = new DropIndexOperation(namespace, keys, ACKNOWLEDGED, true, null)
         execute(dropIndexMethod, session, keys)
         operation = executor.getWriteOperation() as DropIndexOperation
 
@@ -1361,7 +1361,7 @@ class MongoCollectionSpecification extends Specification {
         executor.getClientSession() == session
 
         when:
-        expectedOperation = new DropIndexOperation(namespace, keys, ACKNOWLEDGED)
+        expectedOperation = new DropIndexOperation(namespace, keys, ACKNOWLEDGED, true, null)
         execute(dropIndexMethod, session, keys, new DropIndexOptions().maxTime(100, MILLISECONDS))
         operation = executor.getWriteOperation() as DropIndexOperation
 
@@ -1378,7 +1378,7 @@ class MongoCollectionSpecification extends Specification {
         def executor = new TestOperationExecutor([null, null])
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, ACKNOWLEDGED,
                 true, true, null, readConcern, JAVA_LEGACY, null, TIMEOUT_SETTINGS, executor)
-        def expectedOperation = new DropIndexOperation(namespace, '*', ACKNOWLEDGED)
+        def expectedOperation = new DropIndexOperation(namespace, '*', ACKNOWLEDGED, true, null)
         def dropIndexesMethod = collection.&dropIndexes
 
         when:
@@ -1390,7 +1390,7 @@ class MongoCollectionSpecification extends Specification {
         executor.getClientSession() == session
 
         when:
-        expectedOperation = new DropIndexOperation(namespace, '*', ACKNOWLEDGED)
+        expectedOperation = new DropIndexOperation(namespace, '*', ACKNOWLEDGED, true, null)
         execute(dropIndexesMethod, session, new DropIndexOptions().maxTime(100, MILLISECONDS))
         operation = executor.getWriteOperation() as DropIndexOperation
 
@@ -1409,7 +1409,7 @@ class MongoCollectionSpecification extends Specification {
                 true, true, null, readConcern, JAVA_LEGACY, null, TIMEOUT_SETTINGS, executor)
         def newNamespace = new MongoNamespace(namespace.getDatabaseName(), 'newName')
         def renameCollectionOptions = new RenameCollectionOptions().dropTarget(dropTarget)
-        def expectedOperation = new RenameCollectionOperation(namespace, newNamespace, ACKNOWLEDGED)
+        def expectedOperation = new RenameCollectionOperation(namespace, newNamespace, ACKNOWLEDGED, true, null)
         def renameCollection = collection.&renameCollection
 
         when:

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoDatabaseSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoDatabaseSpecification.groovy
@@ -448,7 +448,7 @@ class MongoDatabaseSpecification extends Specification {
         then:
         expect aggregateIterable, isTheSameAs(new AggregateIterableImpl<>(session, name, Document, Document,
                 codecRegistry, readPreference, readConcern, writeConcern, executor, [], AggregationLevel.DATABASE,
-                false, null, TIMEOUT_SETTINGS), ['codec'])
+                false, false, null, TIMEOUT_SETTINGS), ['codec'])
 
         when:
         aggregateIterable = execute(aggregateMethod, session, [new Document('$match', 1)])
@@ -456,7 +456,7 @@ class MongoDatabaseSpecification extends Specification {
         then:
         expect aggregateIterable, isTheSameAs(new AggregateIterableImpl<>(session, name, Document, Document,
                 codecRegistry, readPreference, readConcern, writeConcern, executor, [new Document('$match', 1)],
-                AggregationLevel.DATABASE, false, null, TIMEOUT_SETTINGS), ['codec'])
+                AggregationLevel.DATABASE, false, false, null, TIMEOUT_SETTINGS), ['codec'])
 
         when:
         aggregateIterable = execute(aggregateMethod, session, [new Document('$match', 1)], BsonDocument)
@@ -464,7 +464,7 @@ class MongoDatabaseSpecification extends Specification {
         then:
         expect aggregateIterable, isTheSameAs(new AggregateIterableImpl<>(session, name, Document, BsonDocument,
                 codecRegistry, readPreference, readConcern, writeConcern, executor, [new Document('$match', 1)],
-                AggregationLevel.DATABASE, false, null, TIMEOUT_SETTINGS), ['codec'])
+                AggregationLevel.DATABASE, false, false, null, TIMEOUT_SETTINGS), ['codec'])
 
         where:
         session << [null, Stub(ClientSession)]


### PR DESCRIPTION
## Summary

Adds overload-only retry support to 11 write-command operations that previously dispatched commands without any retry wrapper.

The retry policy is gated on `retryWrites` and uses:

`includeOverload(maxAdaptiveRetriesSetting, ErrorPropagation.AS_WRITE_POLICY)`

It intentionally does **not** use `includeWrite()`, because these commands are not retryable writes under the retryable-writes spec.

## Commands covered

| Command | Operation |
|---|---|
| `createIndexes` | `CreateIndexesOperation` |
| `dropIndexes` | `DropIndexOperation` |
| `create` | `CreateCollectionOperation` |
| `create` view | `CreateViewOperation` |
| `drop` | `DropCollectionOperation` |
| `dropDatabase` | `DropDatabaseOperation` |
| `renameCollection` | `RenameCollectionOperation` |
| `aggregate` with `$out` / `$merge` | `AggregateToCollectionOperation` |
| `createSearchIndexes` | `CreateSearchIndexesOperation` |
| `updateSearchIndex` | `UpdateSearchIndexesOperation` |
| `dropSearchIndex` | `DropSearchIndexOperation` |

## Implementation details

- Wraps sync dispatch with `createSpecRetryControl` + `decorateWithRetries`.
- Wraps async dispatch with `createSpecRetryControl` + `decorateWithRetriesAsync`.
- Each retry attempt performs a fresh connection selection.
- Adds `onCommand(this::getCommandName)` for retry debug logging.
- Threads `retryWrites` and `maxAdaptiveRetriesSetting` from the client layer through `Operations` into the affected operations.
- Fixes sync aggregate so `$out` / `$merge` respects the actual `retryWrites` setting.

## Scope notes

Already covered before this change:

- `updateMany` / `deleteMany` / `bulkWrite`
- `findAndModify`
- `runCommand`
- `getMore`
- regular read operations through `executeRetryableRead`

Intentionally excluded:

| Excluded | Reason |
|---|---|
| `mapReduce` | Deprecated / removed; no peer-driver precedent. |
| `{w:0}` writes | No server response exists to carry an overload error. |
| `killCursors` | Handled separately. |
| Monitoring / RTT / auth / connection setup | Explicitly excluded by the backpressure spec. |

## Test coverage

- Removed `JAVA-5956` skips for unified client-backpressure tests:
  - `createIndex`
  - `dropIndex`
  - `dropIndexes`
  - aggregate write retry
- Added prose tests for:
  - create collection/view
  - drop collection/database
  - rename collection
  - create/update/drop search index

[JAVA-6308](https://jira.mongodb.org/browse/JAVA-6308)
JAVA-6119 - Fix client construction in backpressure unified tests

**Reason to close:** the `TODO-JAVA-5956` skips that masked the client-construction gap are removed.

The unified backpressure suite now constructs per-test clients such as `client_retryWrites_false` and `client_retryReads_false` according to the spec and executes those scenarios instead of skipping them. No remaining driver-side client-construction issue is known.

---

JAVA-6124 - Test overload retry when `retryReads` / `retryWrites` is false

**Reason to close:** the 34 unified “does not retry if retry*=false” cases run and pass.

They verify gate behavior across command families: retryable reads are gated on `retryReads`, retryable writes on `retryWrites`, and `runCommand` on `retryReads && retryWrites`.

This was a verification ticket, not an implementation ticket, and the suite is now green.

---

JAVA-5956 - Exponential backoff and jitter in retry loops

**Reason to close:** the backoff/jitter implementation already exists in prior work.

All `TODO-JAVA-5956` unified-test skips are now removed: `createIndex` / `dropIndex` / `dropIndexes` / aggregate-write skips via JAVA-6308, and the `getMore` backpressure skip via JAVA-6296.

The only remaining getMore-related skip is a reactive-only `skipNoncompliantReactive` for the cursor auto-close flake, which is not a `TODO-JAVA-5956` marker. No `TODO-JAVA-5956` markers remain.