### PR TITLE
Fix the failing :driver-sync:codenarcTest command 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version=5.10.0-SNAPSHOT
+version=5.11.0-SNAPSHOT
 
 org.gradle.daemon=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en


### PR DESCRIPTION
Fix the failing `:driver-sync:codenarcTest` command by formatting `GridFSBucketSpecification.groovy` 
and fixed `spotlessApply` by formatting `driver-core/build.gradle.kts`

Not a jira ticket

(No changes to the test cases, just making sure that static analysis passes )